### PR TITLE
Fix bug that keep the old end of the file 

### DIFF
--- a/PeerStorage.ts
+++ b/PeerStorage.ts
@@ -56,9 +56,11 @@ export class PeerStorage extends Peer {
             }
             const fp = await Deno.open(path, { read: true, write: true, create: true });
             if (data.data instanceof Uint8Array) {
-                await fp.write(data.data);
+                const writtensize = await fp.write(data.data);
+                await fp.truncate(writtensize);
             } else {
-                await fp.write(new TextEncoder().encode(getDocData(data.data)));
+                const writtensize = await fp.write(new TextEncoder().encode(getDocData(data.data)));
+                await fp.truncate(writtensize);
             }
             await Deno.futime(fp.rid, new Date(data.mtime), new Date(data.mtime));
             fp.close();


### PR DESCRIPTION
When i remove the end of one of the file, the sync doesn't remove it completely. I must add back more text to override it.
To fix it, I just need to add a truncate to the file length to remove the excess text. 