### PR TITLE
feat: add includeInternal option to sync hidden/internal files

### DIFF
--- a/PeerCouchDB.ts
+++ b/PeerCouchDB.ts
@@ -5,6 +5,7 @@ import { decodeBinary } from "./lib/src/string_and_binary/convert.ts";
 import { isPlainText } from "./lib/src/string_and_binary/path.ts";
 import { DispatchFun, Peer } from "./Peer.ts";
 import { createBinaryBlob, createTextBlob, isDocContentSame, unique } from "./lib/src/common/utils.ts";
+import { minimatch } from "minimatch";
 
 // export class PeerInstance()
 
@@ -156,6 +157,9 @@ export class PeerCouchDB extends Peer {
             if (path.startsWith("/")) {
                 path = path.substring(1);
             }
+            if (path.startsWith("i:")) {
+                path = path.substring(2);
+            }
             if (entry.deleted || entry._deleted) {
                 this.sendLog(`${path} delete detected`);
                 await this.dispatchDeleted(path);
@@ -166,7 +170,13 @@ export class PeerCouchDB extends Peer {
             }
         }, (entry) => {
             this.setSetting("since", this.man.since);
-            if (entry.path.indexOf(":") !== -1) return false;
+            if (entry.path.indexOf(":") !== -1) {
+                if (this.config.includeInternal && entry.path.startsWith("i:")) {
+                    const stripped = entry.path.substring(2);
+                    return this.config.includeInternal.some(pattern => minimatch(stripped, pattern, { dot: true }));
+                }
+                return false;
+            }
             return entry.path.startsWith(baseDir);
         });
     }

--- a/dat/config.sample.json
+++ b/dat/config.sample.json
@@ -11,6 +11,7 @@
             "passphrase": "passphrase",
             "obfuscatePassphrase": "passphrase",
             "baseDir": "blog/",
+            "includeInternal": [".claude/**"],
             "useRemoteTweaks": true
         },
         {

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ The configuration file consists of the following structure.
       "passphrase": "passphrase", // E2EE passphrase, if you do not enabled, leave it blank.
       "obfuscatePassphrase": "passphrase", // Path obfuscation passphrase, if you do not enabled, leave it blank. if enabled, set the same value of passphrase.
       "baseDir": "blog/", // Sharing folder
+      "includeInternal": [".claude/**"], // Opt-in glob patterns for internal/hidden files (see caution below). Omit to keep the default of skipping them.
       "useRemoteTweaks":true // Overwrite customChunkSize or minimumChunkSize, and check configuration matches
     },
     {
@@ -108,6 +109,27 @@ The configuration file consists of the following structure.
   ]
 }
 ```
+
+## Synchronising internal/hidden files
+
+By default, the bridge skips all of Self-hosted LiveSync's internal documents — the ones stored with an `i:` prefix, such as files inside hidden folders like `.obsidian/`, `.claude/`, and other tool configuration directories. These are normally left out of the sync.
+
+The optional `includeInternal` field opts specific internal paths back in. It takes an array of [minimatch](https://github.com/isaacs/minimatch) glob patterns that are matched against the path **after** the `i:` prefix is stripped:
+
+```jsonc
+{
+  "type": "couchdb",
+  "name": "test1",
+  // ...
+  "baseDir": "blog/",
+  "includeInternal": [".claude/**"] // Sync everything under .claude/
+}
+```
+
+A document is included when its de-prefixed path matches any one of the patterns. Patterns are matched with the `dot` option, so leading-dot folders such as `.claude/` are matched as expected.
+
+> [!CAUTION]
+> This synchronises files that are normally hidden and internal. Such folders often hold tool configuration that can contain machine-specific paths, local settings, or secrets. Only include patterns you genuinely intend to share, and review what they match before enabling. The option is opt-in: leave it out to keep the default behaviour, where all internal/hidden files are skipped.
 
 ## Realistic example
 

--- a/types.ts
+++ b/types.ts
@@ -18,6 +18,8 @@ export interface PeerStorageConf {
     useChokidar?: boolean;
 }
 export interface PeerCouchDBConf extends DirectFileManipulatorOptions {
+    /** Glob patterns for i:-prefixed (internal) files to sync, e.g. [".claude/**"] */
+    includeInternal?: string[];
     type: "couchdb";
     useRemoteTweaks?: true;
     group?: string;


### PR DESCRIPTION
## Problem

The bridge currently skips all CouchDB documents whose path contains `:`, which filters out all files that Self-hosted LiveSync stores with the `i:` prefix (hidden/internal directories like `.claude/`, `.obsidian/` non-workspace files, etc.).

This makes it impossible to sync tool configuration directories through the bridge — for example, Claude Code stores its skills and configuration in `.claude/`, which never reaches the storage peer.

## Solution

Adds an optional `includeInternal` field to `PeerCouchDBConf` — an array of glob patterns (using minimatch) that opt specific `i:`-prefixed paths back into the sync:

```json
{
  "type": "couchdb",
  "name": "remote-vault",
  "includeInternal": [".claude/**"],
  ...
}
```

When a document with an `i:` prefix matches one of these patterns, it passes the `checkIsInterested` filter and the `i:` prefix is stripped before dispatching to PeerStorage, so the file is written to the correct filesystem path.

**Non-breaking:** the option is optional and defaults to the existing behaviour (all `i:`-prefixed documents are skipped).

## Notes

- Sync loop prevention is handled by the existing `isRepeating()` hash cache — no additional ignore patterns needed
- `dat/config.sample.json` could be updated to document the new option (happy to add if preferred)