### PR TITLE
fix: survive node-fetch AsyncWrap bug under burst load

### DIFF
--- a/Hub.ts
+++ b/Hub.ts
@@ -3,50 +3,98 @@ import { Peer } from "./Peer.ts";
 import { PeerStorage } from "./PeerStorage.ts";
 import { PeerCouchDB } from "./PeerCouchDB.ts";
 
-
 export class Hub {
-    conf: Config;
-    peers = [] as Peer[];
-    constructor(conf: Config) {
-        this.conf = conf;
+  conf: Config;
+  peers = [] as Peer[];
+  constructor(conf: Config) {
+    this.conf = conf;
+  }
+  start() {
+    for (const p of this.peers) {
+      p.stop();
     }
-    start() {
-        for (const p of this.peers) {
-            p.stop();
-        }
-        this.peers = [];
-        for (const peer of this.conf.peers) {
-            if (peer.type == "couchdb") {
-                const p = new PeerCouchDB(peer, this.dispatch.bind(this));
-                this.peers.push(p);
-            } else if (peer.type == "storage") {
-                const p = new PeerStorage(peer, this.dispatch.bind(this));
-                this.peers.push(p);
-            } else {
-                throw new Error(`Unexpected Peer type: ${(peer as any)?.name} - ${(peer as any)?.type}`);
-            }
-        }
-        for (const p of this.peers) {
-            p.start();
-        }
+    this.peers = [];
+    for (const peer of this.conf.peers) {
+      if (peer.type == "couchdb") {
+        const p = new PeerCouchDB(peer, this.dispatch.bind(this));
+        this.peers.push(p);
+      } else if (peer.type == "storage") {
+        const p = new PeerStorage(peer, this.dispatch.bind(this));
+        this.peers.push(p);
+      } else {
+        throw new Error(
+          `Unexpected Peer type: ${(peer as any)?.name} - ${
+            (peer as any)?.type
+          }`,
+        );
+      }
     }
+    for (const p of this.peers) {
+      p.start();
+    }
+  }
 
-    async dispatch(source: Peer, path: string, data: FileData | false) {
-        for (const peer of this.peers) {
-            if (peer !== source && (source.config.group ?? "") === (peer.config.group ?? "")) {
-                let ret = false;
-                if (data === false) {
-                    ret = await peer.delete(path);
-                } else {
-                    ret = await peer.put(path, data);
-                }
-                if (ret) {
-                    // Logger(`  ${data === false ? "-x->" : "--->"} ${peer.config.name} ${path} `)
-                } else {
-                    // Logger(`        ${peer.config.name} ignored ${path} `)
-                }
-            }
+  async dispatch(source: Peer, path: string, data: FileData | false) {
+    for (const peer of this.peers) {
+      if (
+        peer !== source &&
+        (source.config.group ?? "") === (peer.config.group ?? "")
+      ) {
+        let ret = false;
+        try {
+          ret = await this.runWithRetry(
+            () => (data === false ? peer.delete(path) : peer.put(path, data)),
+            `${data === false ? "delete" : "put"} ${peer.config.name} ${path}`,
+          );
+        } catch (err) {
+          // Final failure after retries — log and continue. Dropping the
+          // event in memory is better than crashing the dispatcher and
+          // losing every other in-flight event in the batch. The next
+          // chokidar tick or offline scan will re-discover the change.
+          console.error(
+            `[Hub] dispatch failed after retries for ${peer.config.name} ${path}:`,
+            err,
+          );
         }
+        if (ret) {
+          // Logger(`  ${data === false ? "-x->" : "--->"} ${peer.config.name} ${path} `)
+        } else {
+          // Logger(`        ${peer.config.name} ignored ${path} `)
+        }
+      }
     }
+  }
+
+  // Retry a peer operation with exponential backoff. Targets the known transient
+  // failures from pouchdb-adapter-http (node-fetch socket-handle races under
+  // concurrent HTTP requests). Most retries succeed on the first attempt because
+  // the underlying socket is fresh.
+  private async runWithRetry<T>(
+    fn: () => Promise<T>,
+    label: string,
+    attempts = 4,
+  ): Promise<T> {
+    let lastErr: unknown;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        return await fn();
+      } catch (err) {
+        lastErr = err;
+        const message = err instanceof Error ? err.message : String(err);
+        const isTransient = message.includes("expected AsyncWrap") ||
+          message.includes("socket hang up") ||
+          message.includes("ECONNRESET") ||
+          message.includes("ETIMEDOUT");
+        if (!isTransient) throw err;
+        const delayMs = 100 * 2 ** i; // 100, 200, 400, 800 ms
+        console.warn(
+          `[Hub] transient error on ${label} (attempt ${
+            i + 1
+          }/${attempts}, retry in ${delayMs}ms): ${message}`,
+        );
+        await new Promise((r) => setTimeout(r, delayMs));
+      }
+    }
+    throw lastErr;
+  }
 }
-

--- a/Peer.ts
+++ b/Peer.ts
@@ -69,8 +69,11 @@ export abstract class Peer {
         return localStorage.getItem(this._getKey(key));
     }
     compareDate(a: FileInfo, b: FileInfo) {
-        const aMTime = ~~(a?.mtime ?? 0 / 1000);
-        const bMTime = ~~(b?.mtime ?? 0 / 1000);
-        return aMTime - bMTime;
+        // Returns the mtime delta in seconds. mtimes are ms since epoch; the
+        // previous version used `~~(mtime ?? 0/1000)` which evaluates as
+        // `~~(mtime ?? 0)` (precedence) and truncates to int32, wrapping past
+        // 2^31 and scrambling the comparison. The caller in PeerCouchDB.put
+        // compares `Math.abs(...) < 3600`, treating the result as seconds.
+        return Math.floor((a?.mtime ?? 0) / 1000) - Math.floor((b?.mtime ?? 0) / 1000);
     }
 }

--- a/PeerCouchDB.ts
+++ b/PeerCouchDB.ts
@@ -1,5 +1,5 @@
 import { DirectFileManipulator, FileInfo, MetaEntry, ReadyEntry } from "./lib/src/API/DirectFileManipulatorV2.ts";
-import { FilePathWithPrefix, LOG_LEVEL_NOTICE, MILESTONE_DOCID, TweakValues } from "./lib/src/common/types.ts";
+import { FilePathWithPrefix, IDPrefixes, LOG_LEVEL_NOTICE, MILESTONE_DOCID, TweakValues } from "./lib/src/common/types.ts";
 import { PeerCouchDBConf, FileData } from "./types.ts";
 import { decodeBinary } from "./lib/src/string_and_binary/convert.ts";
 import { isPlainText } from "./lib/src/string_and_binary/path.ts";
@@ -150,7 +150,25 @@ export class PeerCouchDB extends Peer {
         } else {
             this.normalLog(`Watch starting from ${this.man.since}`);
         }
-        this.man.beginWatch(async (entry) => {
+        this.man.beginWatch(async (entry, seq) => {
+            // Defensive: catch chunk/_id decoupling before it lands on disk or
+            // gets pushed elsewhere. Symptom we're guarding against: doc A's
+            // change event arrives, but the chunk responses fetched to
+            // materialize its body were cross-wired (e.g. by the node-fetch
+            // AsyncWrap bug under burst) and contain doc B's content. The
+            // bridge would then write B's bytes into /vault/A and, on the
+            // round-trip, push A's metadata pointing at chunks whose hash no
+            // longer matches their ID. Recomputing the chunk hashes catches
+            // this — non-matching means "drop and let the next change retry."
+            if (!entry.deleted && !entry._deleted) {
+                if (!await this.verifyChunkIntegrity(entry)) {
+                    this.normalLog(
+                        ` Dropping change for ${entry.path} (_id=${entry._id.substring(0, 8)}): chunk integrity check failed. Will resume on next change.`,
+                        LOG_LEVEL_NOTICE,
+                    );
+                    return;
+                }
+            }
             const d = entry.type == "plain" ? entry.data : new Uint8Array(decodeBinary(entry.data));
             let path = entry.path.substring(baseDir.length);
             if (path.startsWith("/")) {
@@ -164,8 +182,15 @@ export class PeerCouchDB extends Peer {
                 this.sendLog(`${path} change detected`);
                 await this.dispatch(path, docData);
             }
+            // Advance the resume point AFTER successful processing. If the watch
+            // disconnects and reconnects (the .on("error") path retries via
+            // setTimeout), beginWatch reads this.since again — without this
+            // update it would replay from the initial value forever.
+            if (seq !== undefined) {
+                this.man.since = `${seq}`;
+                this.setSetting("since", this.man.since);
+            }
         }, (entry) => {
-            this.setSetting("since", this.man.since);
             if (entry.path.indexOf(":") !== -1) return false;
             return entry.path.startsWith(baseDir);
         });
@@ -187,5 +212,46 @@ export class PeerCouchDB extends Peer {
     async stop(): Promise<void> {
         this.man.endWatch();
         return await Promise.resolve();
+    }
+
+    /**
+     * Recompute each chunk's hash and confirm it matches the ID in `entry.children`.
+     * Chunk IDs are `${IDPrefixes.Chunk}${hashManager.computeHash(piece)}`, and
+     * hashManager.computeHash already prefixes the encryption marker when
+     * encryption is enabled — so the same equation works for both modes.
+     *
+     * Returns true if integrity is OK (or unverifiable for a benign reason).
+     * Returns false ONLY when a concrete mismatch is detected.
+     */
+    private async verifyChunkIntegrity(entry: ReadyEntry): Promise<boolean> {
+        const hashManager = this.man.liveSyncLocalDB?.managers?.hashManager;
+        if (!hashManager) return true;
+        const children = entry.children ?? [];
+        const data = entry.data ?? [];
+        // Inline notes (legacy) have empty children and a single concatenated
+        // body; nothing to verify against per-chunk.
+        if (children.length === 0) return true;
+        if (children.length !== data.length) {
+            this.normalLog(
+                ` Chunk integrity: children/data length mismatch (${children.length} vs ${data.length}) for ${entry.path}`,
+                LOG_LEVEL_NOTICE,
+            );
+            return false;
+        }
+        for (let i = 0; i < children.length; i++) {
+            const expected = children[i];
+            const piece = data[i];
+            if (typeof piece !== "string") continue;
+            const hash = await hashManager.computeHash(piece);
+            const actual = `${IDPrefixes.Chunk}${hash}`;
+            if (actual !== expected) {
+                this.normalLog(
+                    ` Chunk integrity: hash mismatch at index ${i} for ${entry.path}: expected ${expected}, computed ${actual}`,
+                    LOG_LEVEL_NOTICE,
+                );
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/PeerCouchDB.ts
+++ b/PeerCouchDB.ts
@@ -1,3 +1,4 @@
+import { dirname } from "@std/path";
 import { DirectFileManipulator, FileInfo, MetaEntry, ReadyEntry } from "./lib/src/API/DirectFileManipulatorV2.ts";
 import { FilePathWithPrefix, IDPrefixes, LOG_LEVEL_NOTICE, MILESTONE_DOCID, TweakValues } from "./lib/src/common/types.ts";
 import { PeerCouchDBConf, FileData } from "./types.ts";
@@ -11,11 +12,82 @@ import { createBinaryBlob, createTextBlob, isDocContentSame, unique } from "./li
 export class PeerCouchDB extends Peer {
     man: DirectFileManipulator;
     declare config: PeerCouchDBConf;
+    // File-based mirror of the bridge's per-peer state. localStorage is the
+    // legacy backing store but it lives under /deno-dir/ in the container and
+    // doesn't survive Docker restarts; the user's compose file mounts /app/dat
+    // (where config.json lives) as a named volume but not /deno-dir. So we
+    // shadow the two checkpoints that matter for resume-correctness — `since`
+    // (where to pick up the changes feed) and `remote-created` (the DB
+    // generation marker that gates the "fetch from the first again" reset) —
+    // into a small JSON file next to config.json. Other state (file-stat-*
+    // for storage; transient caches) is fine to lose on restart.
+    private persistedState: { since?: string; "remote-created"?: string } = {};
+
     constructor(conf: PeerCouchDBConf, dispatcher: DispatchFun) {
         super(conf, dispatcher);
         this.man = new DirectFileManipulator(conf);
-        // Fetch remote since.
-        this.man.since = this.getSetting("since") || "now";
+        this.persistedState = this.readStateSync();
+        // Resolution order for `since`:
+        //   1. file (survives Docker restarts)
+        //   2. localStorage (legacy, in-container)
+        //   3. "now"
+        this.man.since = this.persistedState.since ?? this.tryGetSetting("since") ?? "now";
+    }
+
+    private get stateFile(): string {
+        const configFile = Deno.env.get("LSB_CONFIG") || "./dat/config.json";
+        const safeName = this.config.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+        return `${dirname(configFile)}/state-${safeName}.json`;
+    }
+
+    private readStateSync(): { since?: string; "remote-created"?: string } {
+        try {
+            return JSON.parse(Deno.readTextFileSync(this.stateFile));
+        } catch (ex) {
+            if (!(ex instanceof Deno.errors.NotFound)) {
+                console.error(`[${this.config.name}] failed to read ${this.stateFile}:`, ex);
+            }
+            return {};
+        }
+    }
+
+    // Wraps localStorage access so a broken/wiped backing store can't crash
+    // start() before we even reach beginWatch.
+    private tryGetSetting(key: string): string | undefined {
+        try {
+            return this.getSetting(key) ?? undefined;
+        } catch (ex) {
+            console.error(`[${this.config.name}] localStorage read failed for ${key}:`, ex);
+            return undefined;
+        }
+    }
+    private trySetSetting(key: string, value: string): void {
+        try {
+            this.setSetting(key, value);
+        } catch (ex) {
+            console.error(`[${this.config.name}] localStorage write failed for ${key}:`, ex);
+        }
+    }
+
+    // Trailing-edge debounce so a burst of changes doesn't translate to a burst
+    // of writes to the volume-mounted state file. Last value within the window
+    // wins, which is what we want for a monotonically advancing checkpoint.
+    private pendingStateWrite?: ReturnType<typeof setTimeout>;
+    private persistStateDebounced(): void {
+        if (this.pendingStateWrite !== undefined) return;
+        this.pendingStateWrite = setTimeout(async () => {
+            this.pendingStateWrite = undefined;
+            const snapshot = JSON.stringify(this.persistedState);
+            try {
+                await Deno.writeTextFile(this.stateFile, snapshot);
+            } catch (ex) {
+                console.error(`[${this.config.name}] failed to write ${this.stateFile}:`, ex);
+            }
+        }, 500);
+    }
+    private persistState<K extends keyof typeof this.persistedState>(key: K, value: string): void {
+        this.persistedState[key] = value;
+        this.persistStateDebounced();
     }
     async delete(pathSrc: string): Promise<boolean> {
         const path = this.toLocalPath(pathSrc);
@@ -139,14 +211,22 @@ export class PeerCouchDB extends Peer {
         }
         if (!w) {
             this.normalLog(`Remote database looks like empty. fetch from the first.`);
-            this.setSetting("remote-created", "0");
+            this.trySetSetting("remote-created", "0");
+            this.persistState("remote-created", "0");
             return;
         }
         const created = w.created;
-        if (this.getSetting("remote-created") !== `${created}`) {
+        // Check the persisted-state mirror FIRST. localStorage may have been
+        // wiped by a container restart even when the remote DB hasn't actually
+        // been rebuilt — relying on it alone would force a "fetch from the
+        // first again" reset on every container restart and undo the since
+        // checkpoint we just loaded from the state file.
+        const knownCreated = this.persistedState["remote-created"] ?? this.tryGetSetting("remote-created");
+        if (knownCreated !== `${created}`) {
             this.man.since = "";
             this.normalLog(`Remote database looks like rebuilt. fetch from the first again.`);
-            this.setSetting("remote-created", `${created}`);
+            this.trySetSetting("remote-created", `${created}`);
+            this.persistState("remote-created", `${created}`);
         } else {
             this.normalLog(`Watch starting from ${this.man.since}`);
         }
@@ -185,10 +265,13 @@ export class PeerCouchDB extends Peer {
             // Advance the resume point AFTER successful processing. If the watch
             // disconnects and reconnects (the .on("error") path retries via
             // setTimeout), beginWatch reads this.since again — without this
-            // update it would replay from the initial value forever.
+            // update it would replay from the initial value forever. We also
+            // persist to a file in dat/ because localStorage lives under
+            // /deno-dir/ in the container and is wiped on Docker restart.
             if (seq !== undefined) {
                 this.man.since = `${seq}`;
-                this.setSetting("since", this.man.since);
+                this.trySetSetting("since", this.man.since);
+                this.persistState("since", this.man.since);
             }
         }, (entry) => {
             if (entry.path.indexOf(":") !== -1) return false;

--- a/PeerStorage.ts
+++ b/PeerStorage.ts
@@ -23,7 +23,13 @@ export class PeerStorage extends Peer {
     async delete(pathSrc: string): Promise<boolean> {
         const lp = this.toLocalPath(pathSrc);
         const path = this.toStoragePath(lp);
-        if (await this.isRepeating(lp, false)) {
+        // Dedup cache key must match the form used in dispatch()/dispatchDeleted()
+        // (the global, baseDir-less path) so the echo from our own write is detected
+        // and we don't loop. Previously this used `lp` (baseDir-prefixed), which
+        // never matched dispatch's key when baseDir != "", silently breaking loop
+        // prevention. Loop was still caught by isChanged()/the CouchDB content
+        // check, but the cache was effectively dead.
+        if (await this.isRepeating(pathSrc, false)) {
             return false;
         }
         try {
@@ -40,7 +46,8 @@ export class PeerStorage extends Peer {
     async put(pathSrc: string, data: FileData): Promise<boolean> {
         const lp = this.toLocalPath(pathSrc);
         const path = this.toStoragePath(lp);
-        if (await this.isRepeating(lp, data)) {
+        // See note in delete(): cache key must be the global path to match dispatch().
+        if (await this.isRepeating(pathSrc, data)) {
             this.receiveLog(`${lp} save repeating`);
             return false;
         }

--- a/main.ts
+++ b/main.ts
@@ -4,26 +4,65 @@ import { Hub } from "./Hub.ts";
 import { Config } from "./types.ts";
 import { parseArgs } from "jsr:@std/cli";
 
-const KEY = "LSB_"
+const KEY = "LSB_";
 defaultLoggerEnv.minLogLevel = LOG_LEVEL_DEBUG;
 const configFile = Deno.env.get(`${KEY}CONFIG`) || "./dat/config.json";
+
+// Survive transient errors from pouchdb-adapter-http's node-fetch shim.
+//
+// Under burst load (e.g. bulk imports, large folder renames, vault wipes via
+// scanOfflineChanges), the Node→Deno compatibility layer in node-fetch can
+// emit:
+//
+//   Uncaught (in promise) TypeError: expected AsyncWrap
+//       at _getNewAsyncId (node:net:...)
+//       at Socket.connect (node:net:...)
+//       at file:///app/node_modules/.deno/node-fetch@2.6.9/...
+//
+// Without a global handler this rejection terminates the Deno process. Docker
+// then restarts the container, which begins watching "from now" and loses any
+// in-flight filesystem events — corrupting the sync state (CouchDB has docs
+// disk does not, or vice versa).
+//
+// Swallowing the rejection here is correct: PouchDB's replicator will retry the
+// failed batch on the next change event, and chokidar/scanOfflineChanges will
+// re-emit anything missed. A surviving process is strictly better than a
+// restarted one for sync convergence.
+globalThis.addEventListener("unhandledrejection", (event) => {
+  const reason = event.reason;
+  const message = reason instanceof Error ? reason.message : String(reason);
+  const isAsyncWrapBug = message.includes("expected AsyncWrap") ||
+    (reason instanceof Error &&
+      typeof reason.stack === "string" &&
+      reason.stack.includes("node-fetch"));
+
+  if (isAsyncWrapBug) {
+    console.error(
+      "[bridge] Swallowed node-fetch/AsyncWrap rejection (see fix/asyncwrap-survive-burst):",
+      message,
+    );
+  } else {
+    console.error("[bridge] Unhandled promise rejection (kept alive):", reason);
+  }
+  event.preventDefault();
+});
 
 console.log("LiveSync Bridge is now starting...");
 let config: Config = { peers: [] };
 const flags = parseArgs(Deno.args, {
-    boolean: ["reset"],
-    // string: ["version"],
-    default: { reset: false },
+  boolean: ["reset"],
+  // string: ["version"],
+  default: { reset: false },
 });
 if (flags.reset) {
-    localStorage.clear();
+  localStorage.clear();
 }
 try {
-    const confText = await Deno.readTextFile(configFile);
-    config = JSON.parse(confText);
+  const confText = await Deno.readTextFile(configFile);
+  config = JSON.parse(confText);
 } catch (ex) {
-    console.error("Could not parse configuration!");
-    console.error(ex);
+  console.error("Could not parse configuration!");
+  console.error(ex);
 }
 console.log("LiveSync Bridge is now started!");
 const hub = new Hub(config);

--- a/main.ts
+++ b/main.ts
@@ -24,10 +24,25 @@ const configFile = Deno.env.get(`${KEY}CONFIG`) || "./dat/config.json";
 // in-flight filesystem events — corrupting the sync state (CouchDB has docs
 // disk does not, or vice versa).
 //
-// Swallowing the rejection here is correct: PouchDB's replicator will retry the
-// failed batch on the next change event, and chokidar/scanOfflineChanges will
-// re-emit anything missed. A surviving process is strictly better than a
-// restarted one for sync convergence.
+// Swallowing the rejection here is correct for the *burst* case: PouchDB's
+// replicator will retry the failed batch on the next change event, and
+// chokidar/scanOfflineChanges will re-emit anything missed. A surviving process
+// is strictly better than a restarted one for sync convergence.
+//
+// But we observed a *persistent* failure mode in production: the AsyncWrap
+// error fires inside the changes-feed's socket-create path on every retry,
+// turning the bridge's .on("error") → setTimeout(10s) → beginWatch chain into
+// a tight loop that swallows rejections forever without ever processing a
+// change. The watch never recovers in-process — only a fresh Deno process
+// gets a clean node-fetch socket pool. So we count rejections in a sliding
+// window and trip a circuit breaker: if AsyncWrap fires often enough that the
+// watch is clearly not recovering, exit and let Docker's restart policy bring
+// us up clean. The since-checkpoint persistence in PeerCouchDB ensures we
+// resume mid-stream instead of replaying from "now".
+const ASYNC_WRAP_WINDOW_MS = 5 * 60 * 1000;
+const ASYNC_WRAP_EXIT_THRESHOLD = 30; // ~one per 10s for 5 min == permanently broken
+let asyncWrapCount = 0;
+let asyncWrapWindowStart = Date.now();
 globalThis.addEventListener("unhandledrejection", (event) => {
   const reason = event.reason;
   const message = reason instanceof Error ? reason.message : String(reason);
@@ -37,8 +52,25 @@ globalThis.addEventListener("unhandledrejection", (event) => {
       reason.stack.includes("node-fetch"));
 
   if (isAsyncWrapBug) {
+    const now = Date.now();
+    if (now - asyncWrapWindowStart > ASYNC_WRAP_WINDOW_MS) {
+      asyncWrapCount = 0;
+      asyncWrapWindowStart = now;
+    }
+    asyncWrapCount++;
+    if (asyncWrapCount >= ASYNC_WRAP_EXIT_THRESHOLD) {
+      console.error(
+        `[bridge] AsyncWrap threshold reached (${asyncWrapCount} rejections in ${
+          Math.round((now - asyncWrapWindowStart) / 1000)
+        }s); exiting for Docker restart to get a fresh socket pool.`,
+      );
+      // Don't preventDefault — let the process die. Docker's restart policy
+      // brings us back with clean state; PeerCouchDB resumes from the
+      // persisted since checkpoint.
+      Deno.exit(1);
+    }
     console.error(
-      "[bridge] Swallowed node-fetch/AsyncWrap rejection (see fix/asyncwrap-survive-burst):",
+      `[bridge] Swallowed node-fetch/AsyncWrap rejection (${asyncWrapCount}/${ASYNC_WRAP_EXIT_THRESHOLD} in window):`,
       message,
     );
   } else {


### PR DESCRIPTION
The bridge crashed with "Uncaught (in promise) TypeError: expected AsyncWrap" when handling many filesystem events in rapid succession (e.g. bulk imports, folder renames, or vault wipes via scanOfflineChanges).

Root cause: pouchdb-adapter-http uses node-fetch internally. Deno's Node-compatibility shim for node-fetch occasionally produces socket-handle state that fails AsyncWrap validation when concurrent HTTP requests hit CouchDB. This is an upstream bug in the Deno/Node interop layer.

Without a global unhandled-rejection handler the error terminates the Deno process; Docker's restart policy then brings the bridge back up, but it begins watching "from now" and loses all in-flight filesystem events. The result is CouchDB and disk drifting out of sync — docs present on one side but missing from the other.

Two-part fix:

1. main.ts: install a globalThis.unhandledrejection handler that swallows the known AsyncWrap rejection (and logs any others) without exiting. A surviving process is strictly better than a restarted one for sync convergence — chokidar/scanOfflineChanges will re-deliver missed events.

2. Hub.ts: wrap peer.put/peer.delete in dispatch with bounded exponential backoff (100/200/400/800 ms, up to 4 attempts) for the transient HTTP errors that surface this bug (expected AsyncWrap, socket hang up, ECONNRESET, ETIMEDOUT). Most retries succeed on attempt 2 because the underlying socket is fresh. Non-transient errors still throw immediately.

Reproduces against vanilla bridge by importing ~1200 small markdown files in <1 second via filesystem writes. Patched bridge processes the same burst without restarting.