### PR TITLE
feat: V3 chunk-splitter alignment + burst-load resilience (rebased, slimmed)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib"]
 	path = lib
-	url = https://github.com/vrtmrz/livesync-commonlib
+	url = https://github.com/jagajaga/livesync-commonlib
+	branch = v3-rabin-karp-backport

--- a/PeerCouchDB.ts
+++ b/PeerCouchDB.ts
@@ -1,5 +1,5 @@
 import { DirectFileManipulator, FileInfo, MetaEntry, ReadyEntry } from "./lib/src/API/DirectFileManipulatorV2.ts";
-import { FilePathWithPrefix, LOG_LEVEL_NOTICE, MILESTONE_DOCID, TweakValues } from "./lib/src/common/types.ts";
+import { FilePathWithPrefix, IDPrefixes, LOG_LEVEL_NOTICE, MILESTONE_DOCID, TweakValues } from "./lib/src/common/types.ts";
 import { PeerCouchDBConf, FileData } from "./types.ts";
 import { decodeBinary } from "./lib/src/string_and_binary/convert.ts";
 import { isPlainText } from "./lib/src/string_and_binary/path.ts";
@@ -8,6 +8,7 @@ import { createBinaryBlob, createTextBlob, isDocContentSame, unique } from "./li
 import { minimatch } from "minimatch";
 import { PouchDB } from "./lib/src/pouchdb/pouchdb-http.ts";
 import { promiseWithResolver } from "octagonal-wheels/promises";
+import { dirname } from "@std/path";
 
 // export class PeerInstance()
 
@@ -17,8 +18,19 @@ export class PeerCouchDB extends Peer {
     private _started = promiseWithResolver<void>();
     private _connected = false;
     private _remoteEmpty = false;
+    // File-backed mirror of the two checkpoints that matter for resume-correctness:
+    // `since` (where to resume the changes feed) and `remote-created` (the DB
+    // generation marker gating the "fetch from the first again" reset). The
+    // upstream backing store is localStorage, which lives under /deno-dir/ in the
+    // container and does NOT survive Docker restarts; the compose file mounts
+    // /app/dat (where config.json lives) as a named volume but not /deno-dir. So
+    // without this shadow, every restart loses `since` and resumes from "now",
+    // silently dropping any changes that landed while the bridge was down.
+    private persistedState: { since?: string; "remote-created"?: string } = {};
+    private pendingStateWrite?: ReturnType<typeof setTimeout>;
     constructor(conf: PeerCouchDBConf, dispatcher: DispatchFun) {
         super(conf, dispatcher);
+        this.persistedState = this.readStateSync();
         // The manipulator is built lazily in start(), only after a probe confirms
         // CouchDB is reachable. Building it here would fire its one-shot init
         // against a possibly-down CouchDB (an unhandled rejection) and then be
@@ -44,10 +56,87 @@ export class PeerCouchDB extends Peer {
                 fetch: (url: string | Request, opts?: RequestInit) => globalThis.fetch(url, opts),
             }) as PouchDB.Database<T>;
         };
-        // Fetch remote since.
-        this.man.since = this.getSetting("since") || "now";
+        // Resolve `since`: volume-persisted file first (survives Docker restarts),
+        // then legacy localStorage, then "now". persistedState is kept current in
+        // memory as we watch, so a rebuild on reconnect picks up the latest seq.
+        this.man.since = this.persistedState.since ?? this.getSetting("since") ?? "now";
         if (prev) void prev.close().catch(() => {});
     }
+    private get stateFile(): string {
+        const configFile = Deno.env.get("LSB_CONFIG") || "./dat/config.json";
+        const safeName = this.config.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+        return `${dirname(configFile)}/state-${safeName}.json`;
+    }
+
+    private readStateSync(): { since?: string; "remote-created"?: string } {
+        try {
+            return JSON.parse(Deno.readTextFileSync(this.stateFile));
+        } catch (ex) {
+            if (!(ex instanceof Deno.errors.NotFound)) {
+                console.error(`[${this.config.name}] failed to read ${this.stateFile}:`, ex);
+            }
+            return {};
+        }
+    }
+
+    // Trailing-edge debounce so a burst of changes doesn't translate to a burst
+    // of writes to the volume-mounted state file. Last value within the window
+    // wins, which is what we want for a monotonically advancing checkpoint.
+    private persistStateDebounced(): void {
+        if (this.pendingStateWrite !== undefined) return;
+        this.pendingStateWrite = setTimeout(async () => {
+            this.pendingStateWrite = undefined;
+            const snapshot = JSON.stringify(this.persistedState);
+            try {
+                await Deno.writeTextFile(this.stateFile, snapshot);
+            } catch (ex) {
+                console.error(`[${this.config.name}] failed to write ${this.stateFile}:`, ex);
+            }
+        }, 500);
+    }
+
+    private persistState<K extends keyof typeof this.persistedState>(key: K, value: string): void {
+        this.persistedState[key] = value;
+        this.persistStateDebounced();
+    }
+
+    // Guard against writing a corrupted document to disk: recompute each chunk's
+    // hash from its decrypted piece and confirm it matches the child id the meta
+    // references. A mismatch means a chunk failed to decrypt/reassemble cleanly
+    // (e.g. a transient burst-load failure), so we drop the change and let the
+    // next change event re-deliver it rather than persisting garbage.
+    private async verifyChunkIntegrity(entry: ReadyEntry): Promise<boolean> {
+        const hashManager = this.man.liveSyncLocalDB?.managers?.hashManager;
+        if (!hashManager) return true;
+        const children = entry.children ?? [];
+        const data = entry.data ?? [];
+        // Inline notes (legacy) have empty children and a single concatenated
+        // body; nothing to verify against per-chunk.
+        if (children.length === 0) return true;
+        if (children.length !== data.length) {
+            this.normalLog(
+                ` Chunk integrity: children/data length mismatch (${children.length} vs ${data.length}) for ${entry.path}`,
+                LOG_LEVEL_NOTICE,
+            );
+            return false;
+        }
+        for (let i = 0; i < children.length; i++) {
+            const expected = children[i];
+            const piece = data[i];
+            if (typeof piece !== "string") continue;
+            const hash = await hashManager.computeHash(piece);
+            const actual = `${IDPrefixes.Chunk}${hash}`;
+            if (actual !== expected) {
+                this.normalLog(
+                    ` Chunk integrity: hash mismatch at index ${i} for ${entry.path}: expected ${expected}, computed ${actual}`,
+                    LOG_LEVEL_NOTICE,
+                );
+                return false;
+            }
+        }
+        return true;
+    }
+
     async delete(pathSrc: string): Promise<boolean> {
         await this._started.promise;
         const path = this.toLocalPath(pathSrc);
@@ -258,20 +347,30 @@ export class PeerCouchDB extends Peer {
             if (!w) {
                 this.normalLog(`Remote database looks like empty. fetch from the first.`);
                 this.setSetting("remote-created", "0");
+                this.persistState("remote-created", "0");
                 // Connected fine; there's just nothing to watch yet. Mark it so health
                 // counts this as syncing rather than a stuck "not watching" state.
                 this._remoteEmpty = true;
                 return;
             }
             const created = w.created;
-            if (this.getSetting("remote-created") !== `${created}`) {
+            const knownCreated = this.persistedState["remote-created"] ?? this.getSetting("remote-created");
+            if (knownCreated !== `${created}`) {
                 this.man.since = "";
                 this.normalLog(`Remote database looks like rebuilt. fetch from the first again.`);
                 this.setSetting("remote-created", `${created}`);
+                this.persistState("remote-created", `${created}`);
             } else {
                 this.normalLog(`Watch starting from ${this.man.since}`);
             }
             this.man.beginWatch(async (entry) => {
+                if (!entry.deleted && !entry._deleted && !(await this.verifyChunkIntegrity(entry))) {
+                    this.normalLog(
+                        ` Dropping change for ${entry.path} (_id=${entry._id.substring(0, 8)}): chunk integrity check failed. Will resume on next change.`,
+                        LOG_LEVEL_NOTICE,
+                    );
+                    return;
+                }
                 const d = entry.type == "plain" ? entry.data : new Uint8Array(decodeBinary(entry.data));
                 let path = entry.path.substring(baseDir.length);
                 if (path.startsWith("/")) {
@@ -290,6 +389,7 @@ export class PeerCouchDB extends Peer {
                 }
             }, (entry) => {
                 this.setSetting("since", this.man.since);
+                this.persistState("since", this.man.since);
                 if (entry.path.indexOf(":") !== -1) {
                     if (this.config.includeInternal && entry.path.startsWith("i:")) {
                         const stripped = entry.path.substring(2);

--- a/main.ts
+++ b/main.ts
@@ -12,9 +12,55 @@ import { dirname } from "@std/path";
 // crash-looped the bridge into systemd's start limit and left it down silently
 // for days. Log and keep running instead; the per-peer supervisor re-establishes
 // the actual sync.
+//
+// One rejection class needs special handling, though. Under burst load (bulk
+// imports, large folder renames, vault wipes via scanOfflineChanges) the
+// Node→Deno compat layer in pouchdb-adapter-http's node-fetch shim can emit
+// `TypeError: expected AsyncWrap` from the socket-create path. Swallowing it is
+// correct for the *transient* case — PouchDB retries the batch. But we observed
+// a *persistent* mode in production where it fires on every changes-feed retry,
+// turning the supervisor's reconnect loop into a tight spin that never makes
+// progress; only a fresh Deno process gets a clean node-fetch socket pool. So
+// we count AsyncWrap rejections in a sliding window and trip a circuit breaker:
+// if they fire often enough that the watch is clearly not recovering, exit and
+// let Docker's restart policy bring us up clean. The volume-persisted `since`
+// checkpoint in PeerCouchDB makes the restart resume mid-stream, not from "now".
+const ASYNC_WRAP_WINDOW_MS = 5 * 60 * 1000;
+const ASYNC_WRAP_EXIT_THRESHOLD = 30; // ~one per 10s for 5 min == permanently broken
+let asyncWrapCount = 0;
+let asyncWrapWindowStart = Date.now();
 globalThis.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    const message = reason instanceof Error ? reason.message : String(reason);
+    const isAsyncWrapBug = message.includes("expected AsyncWrap") ||
+        (reason instanceof Error &&
+            typeof reason.stack === "string" &&
+            reason.stack.includes("node-fetch"));
+    if (isAsyncWrapBug) {
+        const now = Date.now();
+        if (now - asyncWrapWindowStart > ASYNC_WRAP_WINDOW_MS) {
+            asyncWrapCount = 0;
+            asyncWrapWindowStart = now;
+        }
+        asyncWrapCount++;
+        if (asyncWrapCount >= ASYNC_WRAP_EXIT_THRESHOLD) {
+            console.error(
+                `[LSB] AsyncWrap threshold reached (${asyncWrapCount} rejections in ${
+                    Math.round((now - asyncWrapWindowStart) / 1000)
+                }s); exiting for Docker restart to get a fresh socket pool.`,
+            );
+            // Don't preventDefault — let the process die so Docker restarts us
+            // clean; PeerCouchDB resumes from the persisted `since` checkpoint.
+            Deno.exit(1);
+        }
+        console.error(
+            `[LSB] Swallowed node-fetch/AsyncWrap rejection (${asyncWrapCount}/${ASYNC_WRAP_EXIT_THRESHOLD} in window):`,
+            message,
+        );
+    } else {
+        console.error("[LSB] Unhandled rejection (kept alive):", reason);
+    }
     event.preventDefault();
-    console.error("[LSB] Unhandled rejection (kept alive):", event.reason);
 });
 
 const KEY = "LSB_"


### PR DESCRIPTION
## Summary

Rebased onto current `main` and **slimmed to only what upstream doesn't already
cover**. Since I first opened this, `main` advanced ~16 commits and independently
shipped much of the hardening this PR originally carried (CouchDB-first init,
generic unhandled-rejection net, npm trystero, `compareDate`, startup
resilience). I've dropped all of that and kept only the genuinely-additive
pieces, plus the V3 chunk-splitter alignment.

### What I found about "V3 decryption failures" (unchanged, still relevant)

V3 chunks use the same `%=` HKDF (E2EE V2) envelope as before, and the pinned
commonlib decrypts them fine. Verified against a live ~78k-doc vault: the bridge
reads/decrypts V3 content with **zero** decrypt/corruption errors. The
`SubtleCrypto.decrypt` storm people saw after enabling V3 is a transient
salt-negotiation/stale-state issue during migration, **not** a missing-format
bug. So this PR does not claim a decryption fix — reading already works.

### Changes (4 files)

- **`main.ts`** (+48) — extend upstream's `unhandledrejection` net with an
  AsyncWrap-specific sliding-window circuit breaker. Upstream's net keeps the
  process alive through transient `expected AsyncWrap` rejections; a *persistent*
  storm spins the reconnect loop forever, so counting them and exiting lets
  Docker restart with a fresh socket pool (resuming from the persisted `since`).

- **`PeerCouchDB.ts`** (+108) — two additions:
  1. **Volume-persisted `since`/`remote-created` checkpoint.** Upstream persists
     these only to localStorage, which lives under `/deno-dir/` and is lost on
     every Docker restart → the changes-feed position resets to "now" and any
     change that landed while down is dropped. This shadows them to a JSON file
     next to `config.json` (the volume-mounted `/app/dat`) and reads it back on
     startup.
  2. **Chunk-integrity gate.** Recompute each chunk's hash from its decrypted
     piece and confirm it matches the child id the meta references; drop the
     change on mismatch and let the next change re-deliver it, rather than
     writing a corrupted file.

- **`.gitmodules` / `lib`** — bump commonlib to the V3 Rabin-Karp splitter so the
  bridge's write-back chunks match V3 clients. Validated against live data: the
  backported splitter reproduces stored chunk IDs exactly (in order) for 8/8 real
  post-V3 notes.

### Submodule: still the two-step you asked for

The submodule currently points at the personal fork. As discussed in the thread,
the splitter (`splitPiecesRabinKarp` from `6abcea69`) only exists in commonlib
commits that also carry the post-0.25.27 service-locator refactor, so it needs
backporting onto the pre-refactor line. I've prepared a clean one-function commit
on top of tag `0.25.27` (`jagajaga/livesync-commonlib@v3-rabin-karp-on-0.25.27`,
`b97fb6e`). **Once that lands in `vrtmrz/livesync-commonlib`, I'll repoint this
submodule at the official commit and drop the fork** — that's the only remaining
item before this is mergeable.

## Test plan

- [x] `deno install` + `deno run -A main.ts` boots, no import errors
- [x] Reads a live V3 vault: 1096 files written, 0 `Decryption failed` / 0
      `Corrupted document` / 0 integrity drops
- [x] Volume `since` checkpoint written to `/app/dat/state-<peer>.json` and read
      back on startup
- [x] Backported splitter reproduces stored chunk IDs 8/8 on real post-V3 notes
- [x] `deno check` adds no new type errors over upstream `main`
- [x] Fresh `git clone --recursive` resolves submodule + V3 splitter
- [ ] Not tested: long-running bidirectional write-back vs fresh CouchDB;
      multi-peer groups
