### PR TITLE
fix: preserve leading underscore in toGlobalPath

### DIFF
--- a/Peer.ts
+++ b/Peer.ts
@@ -25,7 +25,11 @@ export abstract class Peer {
         return ret;
     }
     toGlobalPath(pathSrc: string) {
-        let path = pathSrc.startsWith("_") ? pathSrc.substring(1) : pathSrc;
+        // toLocalPath escapes a leading "_" as "/_" (PouchDB IDs must not start
+        // with "_"). The inverse must strip that leading "/", NOT the "_" —
+        // stripping "_" silently mangles every underscore-prefixed path
+        // (e.g. "_tools/x" -> "tools/x"). Fixed to strip the "/" escape only.
+        let path = pathSrc.startsWith("/") ? pathSrc.substring(1) : pathSrc;
         if (path.startsWith(this.config.baseDir)) {
             path = path.substring(this.config.baseDir.length);
         }


### PR DESCRIPTION
## Problem

`Peer.toGlobalPath()` strips a leading `_` from paths, silently mangling every
underscore-prefixed file/folder. A vault folder such as `_attachments/`
(or `_tools/`, `_templates/`, …) is materialized to storage as `attachments/`.

With path obfuscation enabled it is worse: the mangled path is written back to
CouchDB as a *new* obfuscated document, duplicating content under the wrong path.

## Cause

`toLocalPath()` escapes a leading `_` as `/_`, because PouchDB document IDs must
not start with `_`:

```ts
const ret = (relative.startsWith("_")) ? ("/" + relative) : relative;
```

The inverse `toGlobalPath()` should undo that escape, but it removes the leading
`_` instead of the leading `/`:

```ts
let path = pathSrc.startsWith("_") ? pathSrc.substring(1) : pathSrc; // wrong
```

## Fix

Strip the `/` escape, not the `_`:

```ts
let path = pathSrc.startsWith("/") ? pathSrc.substring(1) : pathSrc;
```

Paths without a leading underscore are unaffected.

## Repro

A vault with a top-level folder beginning with `_` (e.g. `_attachments/note.md`),
synced through a CouchDB peer to a storage peer, lands on disk as
`attachments/note.md` instead of `_attachments/note.md`.
