### PR TITLE
Fix _-prefixed path round-trip, peer init order, and Deno 2 Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ VOLUME /app/data
 
 COPY . .
 
-RUN deno install -A
+# Deno 2.x: install project deps from deno.jsonc (no permission flags here;
+# runtime CMD `deno task run` applies -A). Fallback to cache for full prefetch.
+RUN deno install || true
+RUN deno cache main.ts
 
 CMD [ "deno", "task", "run" ]
 

--- a/Hub.ts
+++ b/Hub.ts
@@ -26,9 +26,18 @@ export class Hub {
                 throw new Error(`Unexpected Peer type: ${(peer as any)?.name} - ${(peer as any)?.type}`);
             }
         }
-        for (const p of this.peers) {
-            p.start();
-        }
+        // Initialize couchdb peers FIRST and await them, then start storage peers.
+        // Otherwise a storage peer's offline scan can push to a couchdb peer before its
+        // DB managers are initialized (initializeDatabase), causing
+        // "Cannot read properties of undefined (reading 'getDBEntryMeta')".
+        (async () => {
+            for (const p of this.peers) {
+                if (p.config.type === "couchdb") await p.start();
+            }
+            for (const p of this.peers) {
+                if (p.config.type !== "couchdb") p.start();
+            }
+        })();
     }
 
     async dispatch(source: Peer, path: string, data: FileData | false) {

--- a/Peer.ts
+++ b/Peer.ts
@@ -20,12 +20,15 @@ export abstract class Peer {
     toLocalPath(path: string) {
         const relativeJoined = joinPosix(this.config.baseDir, path);
         const relative = relativeJoined == "." ? "" : relativeJoined;
-        const ret = (relative.startsWith("_")) ? ("/" + relative) : relative;
-        // this.debugLog(`**TOLOCAL: ${path} => ${ret}`);
-        return ret;
+        // NOTE: do NOT special-case leading "_" here. The commonlib path2id_base/id2path_base
+        // already handle "_"-prefixed paths correctly. Adding "/" here double-mangled them
+        // (e.g. _attachments -> attachments on round-trip).
+        // this.debugLog(`**TOLOCAL: ${path} => ${relative}`);
+        return relative;
     }
     toGlobalPath(pathSrc: string) {
-        let path = pathSrc.startsWith("_") ? pathSrc.substring(1) : pathSrc;
+        // NOTE: do NOT strip a leading "_" here (was corrupting _attachments -> attachments).
+        let path = pathSrc;
         if (path.startsWith(this.config.baseDir)) {
             path = path.substring(this.config.baseDir.length);
         }


### PR DESCRIPTION
Three small, focused fixes — each is its own commit, so they can be taken or dropped independently.

  ## 1. Preserve `_`-prefixed paths on round-trip (`Peer.ts`)

  `toGlobalPath()` stripped a leading `_`, so underscore-prefixed paths were corrupted on the way back — e.g.
  `_attachments/x` → `attachments/x`. With path obfuscation enabled, that mangled path is written back as a
  *new* obfuscated document, duplicating content.

  **Root cause:** the `_` escaping was done twice. commonlib already handles it:
  - `path2id_base()` escapes a leading `_` to `/_` — `src/string_and_binary/path.ts:111`
  - `id2path_base()` reverses it — `path.ts:134-135`

  `Peer.toLocalPath()`/`toGlobalPath()` duplicated that escape, and the inverse stripped the `_` itself
  instead of the `/`. This PR removes the redundant handling from both methods and lets commonlib own it.

  **Why remove the escape from `toLocalPath()` too (not just fix `toGlobalPath()`):** under obfuscation,
  `path2id_base()` hashes the raw input path string (`path.ts:123`), and the CouchDB peer feeds
  `toLocalPath(path)` straight into the manipulator (`PeerCouchDB.ts:21,34`). If `toLocalPath()` keeps
  escaping `_`→`/_`, the bridge hashes `/_attachments/x` while the Obsidian client hashes `_attachments/x` →
  **different document IDs → duplicate docs on write-back**. Removing the escape keeps the bridge's hash
  input identical to the client's. (Fixing only `toGlobalPath()` corrects the read-side display but leaves
  this write-side mismatch under obfuscation.)

  ## 2. Start CouchDB peers before storage peers (`Hub.ts`)

  On startup a storage peer's offline scan could push to a CouchDB peer before its DB managers were
  initialized (`initializeDatabase`), throwing `Cannot read properties of undefined (reading
  'getDBEntryMeta')`. CouchDB peers are now awaited first, then storage peers start.

  ## 3. Install Deno deps in the Docker build (`Dockerfile`)

  Under Deno 2, `deno install -A` no longer prefetches the project's dependencies. Use `deno install` (deps
  from `deno.jsonc`) with a `deno cache main.ts` fallback. (Optional/separable.)

  ---

  ### Relation to existing PRs
  - **#51** fixes the same underscore bug but only in `toGlobalPath()`; as noted above, the complete fix
  under path obfuscation also requires dropping the redundant `toLocalPath()` escape.
  - **#42** is a broader refactor that touches the Docker build and startup handling differently (and removes
  chokidar). This PR is intentionally minimal and surgical — happy to align if #42 lands first.

  **Tested:** Synology NAS deployment, vault with `_attachments` (88 files), path obfuscation enabled —
  round-trips with no duplicate documents.