### PR TITLE
Replace the Commonlib submodule with the published package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -23,7 +21,23 @@ jobs:
           deno-version: v2.x
 
       - name: Install dependencies
-        run: deno install
+        run: deno install --frozen
+
+      - name: Check
+        run: deno task check
+
+      - name: Lint
+        run: deno task lint
 
       - name: Test
         run: deno task test
+
+      - name: Start CouchDB
+        run: docker compose -f test/integration/compose.yml up --detach --wait
+
+      - name: Test CouchDB integration
+        run: deno task test:integration
+
+      - name: Stop CouchDB
+        if: always()
+        run: docker compose -f test/integration/compose.yml down --volumes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib"]
-	path = lib
-	url = https://github.com/vrtmrz/livesync-commonlib

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ VOLUME /app/data
 
 COPY --chown=deno:deno . .
 
-# Deno 2.x: install project deps from deno.jsonc (no permission flags here;
-# runtime CMD `deno task run` applies -A). Fallback to cache for full prefetch.
-RUN deno install || true
-RUN deno cache main.ts
+# Deno 2.x: install the exact dependencies recorded in deno.lock. Runtime
+# permissions remain attached to `deno task run` rather than the install step.
+RUN deno install --frozen
 
 CMD [ "deno", "task", "run" ]

--- a/Peer.ts
+++ b/Peer.ts
@@ -1,10 +1,8 @@
-import { join as joinPosix } from "jsr:@std/path/posix";
-import type { FileInfo } from "./lib/src/API/DirectFileManipulatorV2.ts";
-
-import { FilePathWithPrefix, LOG_LEVEL, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO } from "./lib/src/common/types.ts";
+import { join as joinPosix } from "@std/path/posix";
+import type { FilePathWithPrefix } from "@vrtmrz/livesync-commonlib/compat/common/types";
 import { PeerConf, FileData } from "./types.ts";
-import { Logger } from "octagonal-wheels/common/logger.js";
-import { LRUCache } from "octagonal-wheels/memory/LRUCache.js"
+import { Logger, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, type LOG_LEVEL } from "octagonal-wheels/common/logger";
+import { LRUCache } from "octagonal-wheels/memory/LRUCache";
 import { computeHash } from "./util.ts";
 
 export type DispatchFun = (source: Peer, path: string, data: FileData | false) => Promise<void>;
@@ -123,7 +121,7 @@ export abstract class Peer {
     getSetting(key: string) {
         return localStorage.getItem(this._getKey(key));
     }
-    compareDate(a: FileInfo, b: FileInfo) {
+    compareDate(a: { mtime?: number }, b: { mtime?: number }) {
         const aMTime = ~~(a?.mtime ?? 0 / 1000);
         const bMTime = ~~(b?.mtime ?? 0 / 1000);
         return aMTime - bMTime;

--- a/PeerCouchDB.ts
+++ b/PeerCouchDB.ts
@@ -1,13 +1,25 @@
-import { DirectFileManipulator, FileInfo, MetaEntry, ReadyEntry } from "./lib/src/API/DirectFileManipulatorV2.ts";
-import { FilePathWithPrefix, LOG_LEVEL_NOTICE, MILESTONE_DOCID, TweakValues } from "./lib/src/common/types.ts";
+import { DirectFileManipulator } from "@vrtmrz/livesync-commonlib";
+import {
+    type FilePathWithPrefix,
+    MILESTONE_DOCID,
+    type TweakValues,
+} from "@vrtmrz/livesync-commonlib/compat/common/types";
 import { PeerCouchDBConf, FileData } from "./types.ts";
-import { decodeBinary } from "./lib/src/string_and_binary/convert.ts";
-import { isPlainText } from "./lib/src/string_and_binary/path.ts";
+import { decodeBinary } from "@vrtmrz/livesync-commonlib/compat/string_and_binary/convert";
+import { isPlainText } from "@vrtmrz/livesync-commonlib/compat/string_and_binary/path";
 import { DispatchFun, Peer, PeerHealth } from "./Peer.ts";
-import { createBinaryBlob, createTextBlob, isDocContentSame, unique } from "./lib/src/common/utils.ts";
+import {
+    createBinaryBlob,
+    createTextBlob,
+    isDocContentSame,
+    unique,
+} from "@vrtmrz/livesync-commonlib/compat/common/utils";
 import { minimatch } from "minimatch";
-import { PouchDB } from "./lib/src/pouchdb/pouchdb-http.ts";
 import { promiseWithResolver } from "octagonal-wheels/promises";
+import { LOG_LEVEL_NOTICE } from "octagonal-wheels/common/logger";
+
+type ManipulatorMetaEntry = Parameters<DirectFileManipulator["getByMeta"]>[0];
+type ManipulatorReadyEntry = Awaited<ReturnType<DirectFileManipulator["getByMeta"]>>;
 
 // export class PeerInstance()
 
@@ -20,15 +32,13 @@ export class PeerCouchDB extends Peer {
     constructor(conf: PeerCouchDBConf, dispatcher: DispatchFun) {
         super(conf, dispatcher);
         // The manipulator is built lazily in start(), only after a probe confirms
-        // CouchDB is reachable. Building it here would fire its one-shot init
-        // against a possibly-down CouchDB (an unhandled rejection) and then be
-        // discarded and rebuilt on the first successful connect.
+        // CouchDB is reachable. Building it here would start its one-shot init
+        // against a possibly-down CouchDB, then discard and rebuild it on the
+        // first successful connection.
     }
-    // (Re)create the underlying DirectFileManipulator. Its constructor kicks off a
-    // one-shot async DB init whose `ready` promise never resolves (and whose
-    // rejection is unhandled) when CouchDB is unreachable, so recovering from a
-    // failed connect requires a *fresh* manipulator, not re-awaiting the old,
-    // permanently-pending one.
+    // (Re)create the underlying DirectFileManipulator. Its constructor starts a
+    // one-shot async database initialisation. Recovering from a failed attempt
+    // requires a fresh manipulator because its `ready` promise remains settled.
     private _buildManipulator(): void {
         // Release the previous instance if we're rebuilding. Each retry that gets
         // past the probe but fails to connect (CouchDB reachable but e.g. a config
@@ -36,14 +46,10 @@ export class PeerCouchDB extends Peer {
         // leak. Best-effort and fire-and-forget — it may be mid-init, and we don't
         // want to block the connect path (or fail it) on teardown.
         const prev = this.man as DirectFileManipulator | undefined;
-        this.man = new DirectFileManipulator(this.config);
-        // Use Deno's native fetch to bypass node:http shim issues with Traefik/long-polling
-        this.man.$$createPouchDBInstance = <T extends object>(): PouchDB.Database<T> => {
-            return new PouchDB(this.man.options.url + "/" + this.man.options.database, {
-                auth: { username: this.man.options.username, password: this.man.options.password },
-                fetch: (url: string | Request, opts?: RequestInit) => globalThis.fetch(url, opts),
-            }) as PouchDB.Database<T>;
-        };
+        this.man = new DirectFileManipulator(this.config, {
+            // Bypass node:http compatibility shims for Deno, Traefik, and long-polling connections.
+            fetch: (request, init) => globalThis.fetch(request, init),
+        });
         // Fetch remote since.
         this.man.since = this.getSetting("since") || "now";
         if (prev) void prev.close().catch(() => {});
@@ -69,13 +75,13 @@ export class PeerCouchDB extends Peer {
             return false;
         }
         const type = isPlainText(path) ? "plain" : "newnote";
-        const info: FileInfo = {
+        const info = {
             ctime: data.ctime,
             mtime: data.mtime,
             size: data.size
         };
         const saveData = (data.data instanceof Uint8Array) ? createBinaryBlob(data.data) : createTextBlob(data.data);
-        const old = await this.man.get(path as FilePathWithPrefix, true) as false | MetaEntry;
+        const old = await this.man.get(path as FilePathWithPrefix, true) as false | ManipulatorMetaEntry;
         // const old = await this.getMeta(path as FilePathWithPrefix);
         if (old && Math.abs(this.compareDate(info, old)) < 3600) {
             const oldDoc = await this.man.getByMeta(old);
@@ -98,7 +104,7 @@ export class PeerCouchDB extends Peer {
     async get(pathSrc: FilePathWithPrefix): Promise<false | FileData> {
         await this._started.promise;
         const path = this.toLocalPath(pathSrc) as FilePathWithPrefix;
-        const ret = await this.man.get(path) as false | ReadyEntry;
+        const ret = await this.man.get(path) as false | ManipulatorReadyEntry;
         if (ret === false) {
             return false;
         }
@@ -113,7 +119,7 @@ export class PeerCouchDB extends Peer {
     async getMeta(pathSrc: FilePathWithPrefix): Promise<false | FileData> {
         await this._started.promise;
         const path = this.toLocalPath(pathSrc) as FilePathWithPrefix;
-        const ret = await this.man.get(path, true) as false | MetaEntry;
+        const ret = await this.man.get(path, true) as false | ManipulatorMetaEntry;
         if (ret === false) {
             return false;
         }
@@ -164,9 +170,8 @@ export class PeerCouchDB extends Peer {
         }
     }
 
-    // Wait for the manipulator's one-shot init, but bounded: its `ready` promise
-    // hangs forever if init failed, so race it against a timeout to turn a hang
-    // into a retriable failure.
+    // Bound the manipulator's one-shot initialisation so a transport which accepts
+    // the request but never answers becomes a retriable failure.
     private _waitReady(timeoutMs: number): Promise<void> {
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timeout = new Promise<never>((_, reject) => {

--- a/PeerStorage.ts
+++ b/PeerStorage.ts
@@ -1,16 +1,20 @@
-import { LOG_LEVEL_INFO, LOG_LEVEL_NOTICE, LOG_LEVEL_VERBOSE } from "./lib/src/common/types.ts";
 import { PeerStorageConf, FileData } from "./types.ts";
-import { Logger } from "./lib/src/common/logger.ts";
-import { delay, getDocData } from "./lib/src/common/utils.ts";
-import { isPlainText } from "./lib/src/string_and_binary/path.ts";
+import { delay, getDocData } from "@vrtmrz/livesync-commonlib/compat/common/utils";
+import { isPlainText } from "@vrtmrz/livesync-commonlib/compat/string_and_binary/path";
 import { parse, format, relative, dirname, resolve } from "@std/path";
-import { format as posixFormat, parse as posixParse } from "@std/path/posix"
+import { format as posixFormat, parse as posixParse } from "@std/path/posix";
 import { scheduleOnceIfDuplicated } from "octagonal-wheels/concurrency/lock";
 import { DispatchFun, Peer, PeerHealth } from "./Peer.ts";
 import chokidar from "chokidar";
-import { walk } from 'fs/walk';
+import { walk } from "fs/walk";
 
 import { scheduleTask } from "octagonal-wheels/concurrency/task";
+import {
+    Logger,
+    LOG_LEVEL_INFO,
+    LOG_LEVEL_NOTICE,
+    LOG_LEVEL_VERBOSE,
+} from "octagonal-wheels/common/logger";
 
 export class PeerStorage extends Peer {
     declare config: PeerStorageConf;

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -8,11 +8,11 @@
         "test:integration": "deno test -A test/integration/PeerCouchDB.integration.ts"
     },
     "imports": {
-        "@vrtmrz/livesync-commonlib": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0",
-        "@vrtmrz/livesync-commonlib/compat/common/types": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/common/types",
-        "@vrtmrz/livesync-commonlib/compat/common/utils": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/common/utils",
-        "@vrtmrz/livesync-commonlib/compat/string_and_binary/convert": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/string_and_binary/convert",
-        "@vrtmrz/livesync-commonlib/compat/string_and_binary/path": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/string_and_binary/path",
+        "@vrtmrz/livesync-commonlib": "npm:@vrtmrz/livesync-commonlib@0.1.1",
+        "@vrtmrz/livesync-commonlib/compat/common/types": "npm:@vrtmrz/livesync-commonlib@0.1.1/compat/common/types",
+        "@vrtmrz/livesync-commonlib/compat/common/utils": "npm:@vrtmrz/livesync-commonlib@0.1.1/compat/common/utils",
+        "@vrtmrz/livesync-commonlib/compat/string_and_binary/convert": "npm:@vrtmrz/livesync-commonlib@0.1.1/compat/string_and_binary/convert",
+        "@vrtmrz/livesync-commonlib/compat/string_and_binary/path": "npm:@vrtmrz/livesync-commonlib@0.1.1/compat/string_and_binary/path",
         "@std/cli": "jsr:@std/cli@^1.0.17",
         "fs/walk": "jsr:@std/fs@^1.0.17/",
         "@std/path": "jsr:@std/path@^1.0.9",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,34 +1,26 @@
 {
     "tasks": {
+        "check": "deno check main.ts",
         "dev": "deno run --watch -A main.ts",
+        "lint": "deno lint",
         "run": "deno run -A main.ts",
-        "test": "deno test -A --no-check"
+        "test": "deno test -A",
+        "test:integration": "deno test -A test/integration/PeerCouchDB.integration.ts"
     },
     "imports": {
-        "./lib/src/worker/bgWorker.ts": "./lib/src/worker/bgWorker.mock.ts",
-        "./lib/src/worker/bgWorker": "./lib/src/worker/bgWorker.mock.ts",
+        "@vrtmrz/livesync-commonlib": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0",
+        "@vrtmrz/livesync-commonlib/compat/common/types": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/common/types",
+        "@vrtmrz/livesync-commonlib/compat/common/utils": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/common/utils",
+        "@vrtmrz/livesync-commonlib/compat/string_and_binary/convert": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/string_and_binary/convert",
+        "@vrtmrz/livesync-commonlib/compat/string_and_binary/path": "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0/compat/string_and_binary/path",
+        "@std/cli": "jsr:@std/cli@^1.0.17",
         "fs/walk": "jsr:@std/fs@^1.0.17/",
-        "@std/async": "jsr:@std/async@^1.0.12",
         "@std/path": "jsr:@std/path@^1.0.9",
-        "@types/diff-match-patch": "npm:@types/diff-match-patch@^1.0.36",
         "@types/pouchdb": "npm:@types/pouchdb@^6.4.2",
-        "diff-match-patch": "npm:diff-match-patch@^1.0.5",
-        "octagonal-wheels": "npm:octagonal-wheels@^0.1.39",
-        "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2",
-        "crypto": "node:crypto",
-        "minimatch": "npm:minimatch",
-        "fflate": "npm:fflate@^0.8.2",
-        "pouchdb-core": "npm:pouchdb-core@^9.0.0",
-        "pouchdb-adapter-http": "npm:pouchdb-adapter-http@^9.0.0",
-        "pouchdb-replication": "npm:pouchdb-replication@^9.0.0",
-        "pouchdb-find": "npm:pouchdb-find@^9.0.0",
-        "pouchdb-merge": "npm:pouchdb-merge@^9.0.0",
-        "pouchdb-utils": "npm:pouchdb-utils@^9.0.0",
-        "pouchdb-errors": "npm:pouchdb-errors@^9.0.0",
-        "pouchdb-mapreduce": "npm:pouchdb-mapreduce@^9.0.0",
-        "transform-pouch": "npm:transform-pouch@^2.0.0",
+        "octagonal-wheels": "npm:octagonal-wheels@^0.1.51",
+        "minimatch": "npm:minimatch@^10.2.5",
         "chokidar": "npm:chokidar@^3.5.1",
-        "trystero": "npm:trystero@^0.22.0"
+        "@types/diff-match-patch": "npm:@types/diff-match-patch@^1.0.36"
     },
     "lint": {
         "rules": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,8 +1,8 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/async@^1.0.12": "1.0.12",
     "jsr:@std/cli@*": "1.0.17",
+    "jsr:@std/cli@^1.0.17": "1.0.17",
     "jsr:@std/fs@^1.0.17": "1.0.17",
     "jsr:@std/path@*": "1.0.9",
     "jsr:@std/path@^1.0.9": "1.0.9",
@@ -10,26 +10,12 @@
     "npm:@types/node@*": "24.1.0",
     "npm:@types/pouchdb@*": "6.4.2",
     "npm:@types/pouchdb@^6.4.2": "6.4.2",
+    "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0": "0.1.1-rc.0",
     "npm:chokidar@^3.5.1": "3.6.0",
-    "npm:diff-match-patch@^1.0.5": "1.0.5",
-    "npm:fflate@~0.8.2": "0.8.2",
-    "npm:minimatch@*": "10.0.1",
-    "npm:octagonal-wheels@~0.1.39": "0.1.39",
-    "npm:pouchdb-adapter-http@9": "9.0.0",
-    "npm:pouchdb-core@9": "9.0.0",
-    "npm:pouchdb-errors@9": "9.0.0",
-    "npm:pouchdb-find@9": "9.0.0",
-    "npm:pouchdb-mapreduce@9": "9.0.0",
-    "npm:pouchdb-merge@9": "9.0.0",
-    "npm:pouchdb-replication@9": "9.0.0",
-    "npm:pouchdb-utils@9": "9.0.0",
-    "npm:transform-pouch@2": "2.0.0",
-    "npm:xxhash-wasm@^1.0.2": "1.1.0"
+    "npm:minimatch@^10.2.5": "10.2.6",
+    "npm:octagonal-wheels@~0.1.51": "0.1.51"
   },
   "jsr": {
-    "@std/async@1.0.12": {
-      "integrity": "d1bfcec459e8012846fe4e38dfc4241ab23240ecda3d8d6dfcf6d81a632e803d"
-    },
     "@std/cli@1.0.17": {
       "integrity": "e15b9abe629e17be90cc6216327f03a29eae613365f1353837fa749aad29ce7b"
     },
@@ -44,6 +30,286 @@
     }
   },
   "npm": {
+    "@aws-sdk/checksums@3.1000.24": {
+      "integrity": "sha512-7TWLjypP8kk3savsDBRuhZJx7mBuFFA2136BQhwwLllsAnO4Tmq/p+SXZaNxbuulkzUFz3BZzj0bb4YzexZcNQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/client-s3@3.1101.0": {
+      "integrity": "sha512-16EFb1aTEBgPcfUAWAjjlB57IZCyn7B3rlfT+xqE7M6WoH8AMMU3vFZO0UOitwh/xvvzVx73YED1/n0PU4qBMw==",
+      "dependencies": [
+        "@aws-sdk/checksums",
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/middleware-sdk-s3",
+        "@aws-sdk/signature-v4-multi-region",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/core@3.977.4": {
+      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws-sdk/xml-builder",
+        "@aws/lambda-invoke-store",
+        "@smithy/core",
+        "@smithy/signature-v4",
+        "@smithy/types",
+        "bowser",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-env@3.972.65": {
+      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-http@3.972.67": {
+      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-ini@3.973.10": {
+      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-login",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/credential-provider-imds",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-login@3.972.72": {
+      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-node@3.972.76": {
+      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "dependencies": [
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/credential-provider-imds",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-process@3.972.65": {
+      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-sso@3.973.9": {
+      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-web-identity@3.972.71": {
+      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-sdk-s3@3.972.70": {
+      "integrity": "sha512-APdP0iODt39AkjCjzTFIoFrxDH/Cz3CpWRDKLcsJg7eOnfE1htkxL9BhDoe/xL7cXdoMwh2HBYv3DiT1uf64NQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/signature-v4-multi-region",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/nested-clients@3.997.39": {
+      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/signature-v4-multi-region",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/signature-v4-multi-region@3.996.43": {
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/signature-v4",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/token-providers@3.1100.0": {
+      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/types@3.974.2": {
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/xml-builder@3.972.37": {
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws/lambda-invoke-store@0.3.0": {
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="
+    },
+    "@noble/secp256k1@3.1.0": {
+      "integrity": "sha512-+F7iS7tUMaNGXcc9X3PjmjvuQnXEuSjCRNzVVA2xAcKXgCaP0dHYz4SFyt4FKNHef7sOP//xihowcySSS7PK9g=="
+    },
+    "@smithy/core@3.31.1": {
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/credential-provider-imds@4.4.16": {
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/fetch-http-handler@5.6.13": {
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/md5-js@4.4.16": {
+      "integrity": "sha512-XdPyIiKajNJ5HoLkBYe3EP+Tc9LmyIz/o7bfcCvr7TR7wmtJqAezvyMSV7X+vjTh6l/y3dC81tIc2PirpMpbZw==",
+      "dependencies": [
+        "@smithy/core",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-apply-body-checksum@4.5.16": {
+      "integrity": "sha512-OYAjGlp5NWruU7voitWurcFs4pHBGm3RG10vjWOn5qjs9dXavQhtshjLpCGYRXOIgyJp6tNiCaK6zH8gp8F5Sg==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-http-handler@4.9.13": {
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/signature-v4@5.6.12": {
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/types@4.16.1": {
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-retry@4.5.16": {
+      "integrity": "sha512-oM/8/5H9aG1omF2CzDxE7oxiJQhkonS2Vz1Kd6/76IhvPzCoroA3RVhr0EhAhZmyY6th3WfLK0OpRrphJ3YbgQ==",
+      "dependencies": [
+        "@smithy/core",
+        "tslib"
+      ]
+    },
+    "@trystero-p2p/core@0.25.3": {
+      "integrity": "sha512-lQKNq/ha+vF6kQZrpaXJGzlzxLF/Fhizoy5dwJUYQlkqRrbPup/Jov2EpPX/CPr2X+f79HxVzonkeni3MxmCuQ=="
+    },
+    "@trystero-p2p/nostr@0.25.3": {
+      "integrity": "sha512-nZV9Fl/GXuhIkJSQ+wIkdMoRLO1oSTUL/+vZorukaojeAdOpT/61e8b9Vzbt8L1ktMTaGPEJHw2BG/B5BCwBuw==",
+      "dependencies": [
+        "@noble/secp256k1",
+        "@trystero-p2p/core"
+      ]
+    },
     "@types/debug@4.1.12": {
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dependencies": [
@@ -191,6 +457,57 @@
         "@types/pouchdb-replication"
       ]
     },
+    "@vrtmrz/livesync-commonlib@0.1.1-rc.0": {
+      "integrity": "sha512-rsYN+KcWKIbm4XQiEgx8D6N3Yp9ujkCHgt6LvkT3/Pnw4UHu/FhTaCdR4d2keJYPBIXrgK0w+y2wLjsLBSPSsg==",
+      "dependencies": [
+        "@aws-sdk/client-s3",
+        "@smithy/fetch-http-handler",
+        "@smithy/md5-js",
+        "@smithy/middleware-apply-body-checksum",
+        "@smithy/types",
+        "@smithy/util-retry",
+        "@trystero-p2p/nostr",
+        "diff-match-patch",
+        "events",
+        "fflate",
+        "idb",
+        "markdown-it",
+        "minimatch",
+        "octagonal-wheels",
+        "pouchdb-adapter-http",
+        "pouchdb-adapter-idb",
+        "pouchdb-adapter-indexeddb",
+        "pouchdb-adapter-memory",
+        "pouchdb-core",
+        "pouchdb-errors",
+        "pouchdb-find",
+        "pouchdb-mapreduce",
+        "pouchdb-merge",
+        "pouchdb-replication",
+        "pouchdb-utils",
+        "qrcode-generator",
+        "transform-pouch",
+        "xxhash-wasm-102@npm:xxhash-wasm@1.1.0"
+      ]
+    },
+    "abstract-leveldown@2.7.2": {
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+      "dependencies": [
+        "xtend"
+      ],
+      "deprecated": true
+    },
+    "abstract-leveldown@6.2.3": {
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dependencies": [
+        "buffer",
+        "immediate",
+        "level-concat-iterator",
+        "level-supports",
+        "xtend"
+      ],
+      "deprecated": true
+    },
     "anymatch@3.1.3": {
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dependencies": [
@@ -198,14 +515,23 @@
         "picomatch"
       ]
     },
-    "balanced-match@1.0.2": {
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    "argparse@2.0.1": {
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "balanced-match@4.0.4": {
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "binary-extensions@2.3.0": {
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="
     },
-    "brace-expansion@2.0.1": {
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "bowser@2.14.1": {
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
+    "brace-expansion@5.0.9": {
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dependencies": [
         "balanced-match"
       ]
@@ -214,6 +540,13 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": [
         "fill-range"
+      ]
+    },
+    "buffer@5.7.1": {
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
       ]
     },
     "chokidar@3.6.0": {
@@ -231,8 +564,35 @@
         "fsevents"
       ]
     },
+    "core-util-is@1.0.3": {
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "deferred-leveldown@5.3.0": {
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+      "dependencies": [
+        "abstract-leveldown@6.2.3",
+        "inherits"
+      ],
+      "deprecated": true
+    },
     "diff-match-patch@1.0.5": {
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    },
+    "double-ended-queue@2.1.0-0": {
+      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
+    },
+    "entities@4.5.0": {
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "errno@0.1.8": {
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dependencies": [
+        "prr"
+      ],
+      "bin": true
+    },
+    "events@3.3.0": {
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "fetch-cookie@2.2.0": {
       "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
@@ -241,8 +601,8 @@
         "tough-cookie"
       ]
     },
-    "fflate@0.8.2": {
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    "fflate@0.8.3": {
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="
     },
     "fill-range@7.1.1": {
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
@@ -255,6 +615,9 @@
       "os": ["darwin"],
       "scripts": true
     },
+    "functional-red-black-tree@1.0.1": {
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
+    },
     "glob-parent@5.1.2": {
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dependencies": [
@@ -263,6 +626,15 @@
     },
     "idb@8.0.3": {
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="
+    },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "immediate@3.3.0": {
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-binary-path@2.1.0": {
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
@@ -282,8 +654,90 @@
     "is-number@7.0.0": {
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "minimatch@10.0.1": {
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+    "isarray@0.0.1": {
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "level-codec@9.0.2": {
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dependencies": [
+        "buffer"
+      ],
+      "deprecated": true
+    },
+    "level-concat-iterator@2.0.1": {
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+      "deprecated": true
+    },
+    "level-errors@2.0.1": {
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dependencies": [
+        "errno"
+      ],
+      "deprecated": true
+    },
+    "level-iterator-stream@4.0.2": {
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+      "dependencies": [
+        "inherits",
+        "readable-stream@3.6.2",
+        "xtend"
+      ]
+    },
+    "level-supports@1.0.1": {
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": [
+        "xtend"
+      ]
+    },
+    "levelup@4.4.0": {
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
+      "dependencies": [
+        "deferred-leveldown",
+        "level-errors",
+        "level-iterator-stream",
+        "level-supports",
+        "xtend"
+      ],
+      "deprecated": true
+    },
+    "linkify-it@5.0.2": {
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dependencies": [
+        "uc.micro"
+      ]
+    },
+    "ltgt@2.2.1": {
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA=="
+    },
+    "markdown-it@14.3.0": {
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dependencies": [
+        "argparse",
+        "entities",
+        "linkify-it",
+        "mdurl",
+        "punycode.js",
+        "uc.micro"
+      ],
+      "bin": true
+    },
+    "mdurl@2.1.0": {
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg=="
+    },
+    "memdown@1.4.1": {
+      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
+      "dependencies": [
+        "abstract-leveldown@2.7.2",
+        "functional-red-black-tree",
+        "immediate",
+        "inherits",
+        "ltgt",
+        "safe-buffer@5.1.2"
+      ],
+      "deprecated": true
+    },
+    "minimatch@10.2.6": {
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dependencies": [
         "brace-expansion"
       ]
@@ -297,8 +751,8 @@
     "normalize-path@3.0.0": {
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
-    "octagonal-wheels@0.1.39": {
-      "integrity": "sha512-Ue6xdEYoHubEsXRg2ZHx1At566nSOjPU3Nj35l9BwuSR7uD1YUg2KLgbDVmcZslocKXQWXb9PjFdvAay79TyBw==",
+    "octagonal-wheels@0.1.51": {
+      "integrity": "sha512-KTlfqKPjobHJg/t3A539srnFf+VHr1aXkHSmsNDDpiI5UFC7FamZ95dWpJfGE2EI/HULR5hveQDgkazmz8SAcg==",
       "dependencies": [
         "idb"
       ]
@@ -324,6 +778,62 @@
         "pouchdb-binary-utils",
         "pouchdb-errors",
         "pouchdb-fetch",
+        "pouchdb-utils"
+      ]
+    },
+    "pouchdb-adapter-idb@9.0.0": {
+      "integrity": "sha512-2oLlgwMyOQwdKuzrEmOv8T7jFVgX7JgT4Cr81zX3eiiRClp7xXGgjv41ZRdVCAbM530sIN8BudafaQRVFKRVmA==",
+      "dependencies": [
+        "pouchdb-adapter-utils",
+        "pouchdb-binary-utils",
+        "pouchdb-errors",
+        "pouchdb-json",
+        "pouchdb-merge",
+        "pouchdb-utils"
+      ]
+    },
+    "pouchdb-adapter-indexeddb@9.0.0": {
+      "integrity": "sha512-/mcCbnVR0VKwtVZWKf8lVSdADLD0yApjFudu4d+0jeLWAeBSGZBRKYlogz2PGs4uTA7GVc2TXjVCNGUdkCM9ZQ==",
+      "dependencies": [
+        "pouchdb-adapter-utils",
+        "pouchdb-binary-utils",
+        "pouchdb-errors",
+        "pouchdb-md5",
+        "pouchdb-merge",
+        "pouchdb-utils"
+      ]
+    },
+    "pouchdb-adapter-leveldb-core@9.0.0": {
+      "integrity": "sha512-b3ZGPtVXyivGL5SK3AIDG7PrNsZdoDpGFkmTytDTtctkVhxOg71gnXXP+CrupENPqSNG/eGbKW4w+bbMpxy6aA==",
+      "dependencies": [
+        "double-ended-queue",
+        "levelup",
+        "pouchdb-adapter-utils",
+        "pouchdb-binary-utils",
+        "pouchdb-core",
+        "pouchdb-errors",
+        "pouchdb-json",
+        "pouchdb-md5",
+        "pouchdb-merge",
+        "pouchdb-utils",
+        "sublevel-pouchdb",
+        "through2"
+      ]
+    },
+    "pouchdb-adapter-memory@9.0.0": {
+      "integrity": "sha512-XbCwJ5f5U9dGdkiDikzYjTebdPHuA6Ghylx1Pq0lDe4y6l8R9xhjDSUy56pJ8G2F4Z+8QdB5FBY9EQoFlFSXWQ==",
+      "dependencies": [
+        "memdown",
+        "pouchdb-adapter-leveldb-core"
+      ]
+    },
+    "pouchdb-adapter-utils@9.0.0": {
+      "integrity": "sha512-hmbm4ey0HL0vtoY1tRTPIt2FfYjvMh3DWoGGSxXDTS73qTFQ+Fhhi5I0AnN9PcD2omfKQAVXiYks4kkMvlAHqA==",
+      "dependencies": [
+        "pouchdb-binary-utils",
+        "pouchdb-errors",
+        "pouchdb-md5",
+        "pouchdb-merge",
         "pouchdb-utils"
       ]
     },
@@ -388,6 +898,12 @@
         "pouchdb-md5"
       ]
     },
+    "pouchdb-json@9.0.0": {
+      "integrity": "sha512-aI41mYVyI195GXuT1Ys7mLIB/Mvrz11ihoTP6km6hYqVgSuaUxuZcFUozlyTJiZXr7H5kdhNgclhlVnjir4JAA==",
+      "dependencies": [
+        "vuvuzela"
+      ]
+    },
     "pouchdb-mapreduce-utils@9.0.0": {
       "integrity": "sha512-Bjh8W6QXqp1j7MKmHhYYp5cYlcQsm5drD8Jd/F+ZlfNt18uiD2SQXWzGM5797+tiW/LszFGb8ttw0uHWjxufCQ==",
       "dependencies": [
@@ -442,17 +958,43 @@
     "pouchdb-wrappers@5.0.0": {
       "integrity": "sha512-fXqsVn+rmlPtxaAIGaQP5TkiaT39OMwvMk+ScLLtHrmfXD2KBO6fe/qBl38N/rpTn0h/A058dPN4fLAHt550zA=="
     },
+    "prr@1.0.1": {
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
+    },
     "psl@1.15.0": {
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dependencies": [
         "punycode"
       ]
     },
+    "punycode.js@2.3.1": {
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
+    },
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
+    "qrcode-generator@1.5.2": {
+      "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw=="
+    },
     "querystringify@2.2.0": {
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "readable-stream@1.1.14": {
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dependencies": [
+        "core-util-is",
+        "inherits",
+        "isarray",
+        "string_decoder@0.10.31"
+      ]
+    },
+    "readable-stream@3.6.2": {
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": [
+        "inherits",
+        "string_decoder@1.3.0",
+        "util-deprecate"
+      ]
     },
     "readdirp@3.6.0": {
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
@@ -463,11 +1005,41 @@
     "requires-port@1.0.0": {
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
-    "set-cookie-parser@2.7.1": {
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+    "safe-buffer@5.1.2": {
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "set-cookie-parser@2.7.2": {
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "spark-md5@3.0.2": {
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
+    },
+    "string_decoder@0.10.31": {
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "string_decoder@1.3.0": {
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": [
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "sublevel-pouchdb@9.0.0": {
+      "integrity": "sha512-pX4r8+F7wuts0C81kUJ341h4bl2aRe7qV572FE8X1FMz9VkKlmi2nPD1vfeiOJXz5Y09I4MHjGULAbqvTfQZEQ==",
+      "dependencies": [
+        "level-codec",
+        "ltgt",
+        "readable-stream@1.1.14"
+      ]
+    },
+    "through2@3.0.2": {
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "dependencies": [
+        "inherits",
+        "readable-stream@3.6.2"
+      ]
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -493,6 +1065,12 @@
         "pouchdb-wrappers"
       ]
     },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "uc.micro@2.1.0": {
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
     "undici-types@7.8.0": {
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
     },
@@ -506,9 +1084,16 @@
         "requires-port"
       ]
     },
+    "util-deprecate@1.0.2": {
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "uuid@8.3.2": {
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": true,
       "bin": true
+    },
+    "vuvuzela@1.0.3": {
+      "integrity": "sha512-Tm7jR1xTzBbPW+6y1tknKiEhz04Wf/1iZkcTJjSFcpNko43+dFW6+OOeQe9taJIug3NdfUAjFKgUSyQrIKaDvQ=="
     },
     "webidl-conversions@3.0.1": {
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
@@ -520,33 +1105,24 @@
         "webidl-conversions"
       ]
     },
+    "xtend@4.0.2": {
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
     "xxhash-wasm@1.1.0": {
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/async@^1.0.12",
+      "jsr:@std/cli@^1.0.17",
       "jsr:@std/fs@^1.0.17",
       "jsr:@std/path@^1.0.9",
       "npm:@types/diff-match-patch@^1.0.36",
       "npm:@types/pouchdb@^6.4.2",
+      "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0",
       "npm:chokidar@^3.5.1",
-      "npm:diff-match-patch@^1.0.5",
-      "npm:fflate@~0.8.2",
-      "npm:minimatch@*",
-      "npm:octagonal-wheels@~0.1.39",
-      "npm:pouchdb-adapter-http@9",
-      "npm:pouchdb-core@9",
-      "npm:pouchdb-errors@9",
-      "npm:pouchdb-find@9",
-      "npm:pouchdb-mapreduce@9",
-      "npm:pouchdb-merge@9",
-      "npm:pouchdb-replication@9",
-      "npm:pouchdb-utils@9",
-      "npm:transform-pouch@2",
-      "npm:trystero@0.22",
-      "npm:xxhash-wasm@^1.0.2"
+      "npm:minimatch@^10.2.5",
+      "npm:octagonal-wheels@~0.1.51"
     ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -10,7 +10,7 @@
     "npm:@types/node@*": "24.1.0",
     "npm:@types/pouchdb@*": "6.4.2",
     "npm:@types/pouchdb@^6.4.2": "6.4.2",
-    "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0": "0.1.1-rc.0",
+    "npm:@vrtmrz/livesync-commonlib@0.1.1": "0.1.1",
     "npm:chokidar@^3.5.1": "3.6.0",
     "npm:minimatch@^10.2.5": "10.2.6",
     "npm:octagonal-wheels@~0.1.51": "0.1.51"
@@ -457,8 +457,8 @@
         "@types/pouchdb-replication"
       ]
     },
-    "@vrtmrz/livesync-commonlib@0.1.1-rc.0": {
-      "integrity": "sha512-rsYN+KcWKIbm4XQiEgx8D6N3Yp9ujkCHgt6LvkT3/Pnw4UHu/FhTaCdR4d2keJYPBIXrgK0w+y2wLjsLBSPSsg==",
+    "@vrtmrz/livesync-commonlib@0.1.1": {
+      "integrity": "sha512-lWPcCYgvBKU3fw3eqpvp6WUd1uVfpQicy9yXbVVgFNJ48VDT9JeqdWaxrCWrYZbT4x8HGUSWmWNNkiult2JfLQ==",
       "dependencies": [
         "@aws-sdk/client-s3",
         "@smithy/fetch-http-handler",
@@ -1119,7 +1119,7 @@
       "jsr:@std/path@^1.0.9",
       "npm:@types/diff-match-patch@^1.0.36",
       "npm:@types/pouchdb@^6.4.2",
-      "npm:@vrtmrz/livesync-commonlib@0.1.1-rc.0",
+      "npm:@vrtmrz/livesync-commonlib@0.1.1",
       "npm:chokidar@^3.5.1",
       "npm:minimatch@^10.2.5",
       "npm:octagonal-wheels@~0.1.51"

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,7 @@
-import { defaultLoggerEnv } from "./lib/src/common/logger.ts";
-import { LOG_LEVEL_DEBUG } from "./lib/src/common/logger.ts";
+import { defaultLoggerEnv, LOG_LEVEL_DEBUG } from "octagonal-wheels/common/logger";
 import { Hub } from "./Hub.ts";
 import { Config } from "./types.ts";
-import { parseArgs } from "jsr:@std/cli";
+import { parseArgs } from "@std/cli";
 import { dirname } from "@std/path";
 
 // Last-resort safety net for a long-running sync daemon. A transient backend

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Of course, it is multi-directional!
 1. Clone the GitHub Repository
 
 ```git
-git clone --recursive https://github.com/vrtmrz/livesync-bridge
+git clone https://github.com/vrtmrz/livesync-bridge
 ```
 
 2. Open the config file dat/config.sample.json, edit and save to
@@ -73,7 +73,7 @@ The configuration file consists of the following structure.
       "customChunkSize": 100,
       "minimumChunkSize": 20,
       "passphrase": "passphrase", // E2EE passphrase, if you do not enabled, leave it blank.
-      "obfuscatePassphrase": "passphrase", // Path obfuscation passphrase, if you do not enabled, leave it blank. if enabled, set the same value of passphrase.
+      "obfuscatePassphrase": "passphrase", // Path obfuscation passphrase. Leave blank to disable it; this may differ from passphrase.
       "baseDir": "blog/", // Sharing folder
       "includeInternal": [".claude/**"], // Opt-in glob patterns for internal/hidden files (see caution below). Omit to keep the default of skipping them.
       "useRemoteTweaks":true // Overwrite customChunkSize or minimumChunkSize, and check configuration matches
@@ -186,7 +186,7 @@ Totally, all files are synchronized like this:
       "username": "cornbread",
       "password": "tackle",
       "passphrase": "glucose", // E2EE passphrase, if you do not enabled, leave it blank.
-      "obfuscatePassphrase": "glucose", // Path obfuscation passphrase, if you do not enabled, leave it blank. if enabled, set the same value of passphrase.
+      "obfuscatePassphrase": "glucose", // Path obfuscation passphrase. Leave blank to disable it; this may differ from passphrase.
       "customChunkSize": 100,
       "minimumChunkSize": 20,
       "baseDir": "shared/" // Sharing folder
@@ -199,7 +199,7 @@ Totally, all files are synchronized like this:
       "username": "common_user",
       "password": "resu_nommoc",
       "passphrase": "cocoa", // E2EE passphrase, if you do not enabled, leave it blank.
-      "obfuscatePassphrase": "cocoa", // Path obfuscation passphrase, if you do not enabled, leave it blank. if enabled, set the same value of passphrase.
+      "obfuscatePassphrase": "cocoa", // Path obfuscation passphrase. Leave blank to disable it; this may differ from passphrase.
       "customChunkSize": 100,
       "minimumChunkSize": 20,
       "baseDir": "" // Sharing folder

--- a/test/integration/PeerCouchDB.integration.ts
+++ b/test/integration/PeerCouchDB.integration.ts
@@ -1,0 +1,118 @@
+import type { FilePathWithPrefix } from "@vrtmrz/livesync-commonlib/compat/common/types";
+import { defaultLogger, setGlobalLogFunction } from "octagonal-wheels/common/logger";
+import { PeerCouchDB } from "../../PeerCouchDB.ts";
+import type { FileData, PeerCouchDBConf } from "../../types.ts";
+
+const couchDbUrl = Deno.env.get("COUCHDB_URL") ?? "http://127.0.0.1:5989";
+const couchDbUsername = Deno.env.get("COUCHDB_USERNAME") ?? "admin";
+const couchDbPassword = Deno.env.get("COUCHDB_PASSWORD") ?? "testpassword";
+const authHeader = `Basic ${btoa(`${couchDbUsername}:${couchDbPassword}`)}`;
+
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) throw new Error(message);
+}
+
+function assertEquals<T>(actual: T, expected: T, message: string): void {
+    if (actual !== expected) {
+        throw new Error(`${message}\nactual=${String(actual)}\nexpected=${String(expected)}`);
+    }
+}
+
+async function waitForCouchDb(): Promise<void> {
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(`${couchDbUrl}/_up`, { headers: { authorization: authHeader } });
+            if (response.ok) return;
+        } catch {
+            // CouchDB is still starting.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    throw new Error(`CouchDB did not become ready at ${couchDbUrl} within 60 seconds`);
+}
+
+async function requestDatabase(database: string, method: "PUT" | "DELETE"): Promise<Response> {
+    return await fetch(`${couchDbUrl}/${database}`, {
+        method,
+        headers: { authorization: authHeader },
+    });
+}
+
+function makeConfig(name: string, database: string): PeerCouchDBConf {
+    return {
+        type: "couchdb",
+        name,
+        database,
+        username: couchDbUsername,
+        password: couchDbPassword,
+        url: couchDbUrl,
+        passphrase: "content-encryption-passphrase",
+        obfuscatePassphrase: "path-obfuscation-passphrase",
+        baseDir: "",
+    };
+}
+
+Deno.test("PeerCouchDB exchanges files with distinct content and path passphrases", async () => {
+    await waitForCouchDb();
+
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const database = `livesync_bridge_${suffix}`;
+    const created = await requestDatabase(database, "PUT");
+    assert(created.ok, `Could not create integration database: HTTP ${created.status} ${await created.text()}`);
+
+    const peerA = new PeerCouchDB(makeConfig(`integration-a-${suffix}`, database), () => Promise.resolve());
+    const peerB = new PeerCouchDB(makeConfig(`integration-b-${suffix}`, database), () => Promise.resolve());
+    const path = "note.md" as FilePathWithPrefix;
+    const serviceLogs: string[] = [];
+    setGlobalLogFunction((message) => serviceLogs.push(String(message)));
+
+    try {
+        await Promise.all([peerA.start(), peerB.start()]);
+        assert(peerA.man.liveSyncLocalDB.isReady, "The first direct database should finish initialisation");
+        assert(peerB.man.liveSyncLocalDB.isReady, "The second direct database should finish initialisation");
+
+        const first: FileData = {
+            ctime: 1_700_000_000_000,
+            mtime: 1_700_000_000_000,
+            size: 5,
+            data: ["hello"],
+        };
+        assert(await peerA.put(path, first), "The first peer should store the file");
+
+        const readByB = await peerB.get(path);
+        assert(readByB !== false, "The second peer should read the file");
+        assertEquals(readByB.data.join(""), "hello", "The second peer should receive the original content");
+
+        const second: FileData = {
+            ...first,
+            mtime: first.mtime + 10_000,
+            size: 7,
+            data: ["updated"],
+        };
+        assert(await peerB.put(path, second), "The second peer should update the file");
+
+        const readByA = await peerA.get(path);
+        assert(readByA !== false, "The first peer should read the updated file");
+        assertEquals(readByA.data.join(""), "updated", "The first peer should receive the updated content");
+
+        assert(await peerB.delete(path), "The second peer should delete the file");
+        assertEquals(await peerA.get(path), false, "The first peer should observe the deletion");
+
+        const failedInitialisationLogs = serviceLogs.filter((message) =>
+            message.includes("Failed to open KeyValueDB") ||
+            message.includes("No replicator is available") ||
+            message.includes("prevented the database from being ready")
+        );
+        assertEquals(
+            failedInitialisationLogs.length,
+            0,
+            `Direct database initialisation should not run unrelated application services: ${failedInitialisationLogs.join("; ")}`,
+        );
+    } finally {
+        await Promise.allSettled([peerA.stop(), peerB.stop()]);
+        await Promise.allSettled([peerA.man?.close(), peerB.man?.close()]);
+        setGlobalLogFunction(defaultLogger);
+        await requestDatabase(database, "DELETE");
+    }
+});

--- a/test/integration/compose.yml
+++ b/test/integration/compose.yml
@@ -1,0 +1,15 @@
+name: livesync-bridge-integration
+
+services:
+  couchdb:
+    image: couchdb:3.5.0
+    environment:
+      COUCHDB_USER: admin
+      COUCHDB_PASSWORD: testpassword
+    ports:
+      - "5989:5984"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent --user admin:testpassword http://127.0.0.1:5984/_up > /dev/null"]
+      interval: 1s
+      timeout: 5s
+      retries: 60

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-import type { DirectFileManipulatorOptions } from "./lib/src/API/DirectFileManipulator.ts";
+import type { DirectFileManipulatorOptions } from "@vrtmrz/livesync-commonlib";
 
 export interface Config {
     peers: PeerConf[];

--- a/util.test.ts
+++ b/util.test.ts
@@ -12,3 +12,14 @@ Deno.test("computeHash returns stable SHA-256 hex for bytes and text chunks", as
     assertEquals(await computeHashUInt8Array(new TextEncoder().encode("hello")), expected, "byte hash should match SHA-256");
     assertEquals(await computeHash(["hello"]), expected, "text chunk hash should match SHA-256");
 });
+
+Deno.test("computeHash accepts the ArrayBuffer-backed bytes used by file data", async () => {
+    const bytes: Uint8Array<ArrayBuffer> = new Uint8Array(new ArrayBuffer(5));
+    bytes.set(new TextEncoder().encode("hello"));
+
+    assertEquals(
+        await computeHash(bytes),
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        "ArrayBuffer-backed byte hash should match SHA-256",
+    );
+});

--- a/util.ts
+++ b/util.ts
@@ -1,9 +1,12 @@
-import { uint8ArrayToHexString } from "./lib/src/string_and_binary/convert.ts";
-import { createTextBlob } from "./lib/src/common/utils.ts";
+import { createTextBlob } from "@vrtmrz/livesync-commonlib/compat/common/utils";
+import { uint8ArrayToHexString } from "@vrtmrz/livesync-commonlib/compat/string_and_binary/convert";
 
 
 export async function computeHashUInt8Array(key: Uint8Array) {
-    const digest = await crypto.subtle.digest('SHA-256', key);
+    const digestInput = key.buffer instanceof ArrayBuffer
+        ? new Uint8Array(key.buffer, key.byteOffset, key.byteLength)
+        : new Uint8Array(key);
+    const digest = await crypto.subtle.digest('SHA-256', digestInput);
     return uint8ArrayToHexString(new Uint8Array(digest));
 }
 


### PR DESCRIPTION
Replace the vendored Commonlib submodule with the published package so Bridge uses the supported Deno-compatible direct file manipulation boundary and reproducible dependencies.

## Summary

- Remove the Commonlib Git submodule and consume `@vrtmrz/livesync-commonlib@0.1.1` from npm.
- Supply Deno's native `fetch` implementation to `DirectFileManipulator`, while preserving separate content-encryption and path-obfuscation passphrases.
- Use a frozen Deno lockfile in CI and the production Docker image.
- Add type checking, linting, unit coverage, and a CouchDB integration test covering create, read, update, and delete operations.
- Update the cloning and passphrase guidance in the README.

## Rationale

Bridge only requires direct file manipulation over CouchDB. It does not need an application-owned replication runtime or key-value database lifecycle. Using the published package keeps that boundary explicit and removes the duplicated Commonlib source tree.

## Verification

- Clean `deno install --frozen`
- `deno task check`
- `deno task lint`
- `deno task test`
- `deno task test:integration` against CouchDB 3.5.0
- Production Docker image build
- Type checking and unit tests inside the production image

The exact published `@vrtmrz/livesync-commonlib@0.1.1` artefact was validated in this consumer before the package's `latest` dist-tag was promoted.
